### PR TITLE
Date Serialization Fix

### DIFF
--- a/src/main/webapp/basic-search-helper.js
+++ b/src/main/webapp/basic-search-helper.js
@@ -1,4 +1,4 @@
-const { Map, fromJS } = require('immutable')
+const { Map, Set, fromJS } = require('immutable')
 import { locationTypes } from './location'
 export const APPLY_TO_KEY = 'applyTo'
 export const DATATYPES_KEY = 'datatypes'
@@ -112,9 +112,7 @@ export const fromFilterTree = filterTree => {
           }
 
           if (datatypeProperties.includes(filters[0].property)) {
-            const applyTo = Array.from(
-              new Set(filters.map(({ value }) => value))
-            )
+            const applyTo = Set(filters.map(({ value }) => value)).toJSON()
             return accumulator.set(DATATYPES_KEY, applyTo)
           }
         }

--- a/src/main/webapp/intrigue-api/cql.js
+++ b/src/main/webapp/intrigue-api/cql.js
@@ -604,9 +604,6 @@ function write(filter) {
       }
     case temporalClass:
       const toStringDate = date => {
-        if (typeof date.toISOString === 'function') {
-          return date.toISOString()
-        }
         return date.toString()
       }
 

--- a/src/main/webapp/time-range.js
+++ b/src/main/webapp/time-range.js
@@ -21,7 +21,23 @@ import { Map } from 'immutable'
 const relativeUnits = ['minutes', 'hours', 'days', 'months', 'years']
 
 const isValidDate = date => {
-  return date !== undefined && date !== null && !isNaN(date.valueOf())
+  if (date === undefined) {
+    return false
+  }
+
+  if (date === null) {
+    return false
+  }
+
+  if (typeof date === 'string') {
+    return isValidDate(new Date(date))
+  }
+
+  if (date instanceof Date) {
+    return !isNaN(date.valueOf())
+  }
+
+  return false
 }
 
 export const createTimeRange = timeRange => {
@@ -238,8 +254,12 @@ const DatePicker = props => {
         label={label}
         value={state}
         onChange={(date, value) => {
+          if (isValidDate(date)) {
+            onChange(date.toISOString())
+          } else {
+            onChange('')
+          }
           setState(value)
-          onChange(date)
         }}
         KeyboardButtonProps={{
           'aria-label': 'change date',


### PR DESCRIPTION
  Using iso strings for dates instead of passing date objects so that
  the query tool always returns valid filter tree data structures

  Removing use of ES6 Set in favor of Immutable