### PR TITLE
Fixing bug that crashes Workspaces when the map is shown

### DIFF
--- a/src/main/webapp/maps/world-map.js
+++ b/src/main/webapp/maps/world-map.js
@@ -106,7 +106,9 @@ const WorldMap = ({
     if (mapDiv.current) {
       const width = mapDiv.current.parentElement.offsetWidth
       const height = mapDiv.current.parentElement.offsetHeight
-      setContainer({ width, height })
+      if (width !== container.width || height !== container.height) {
+        setContainer({ width, height })
+      }
     }
   })
   useLayoutEffect(


### PR DESCRIPTION
WorldMap has an infinite recursion bug in the effect for detecting parent element resizing.