### PR TITLE
Added location input for line, polygon, and bounding box.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "apollo-server-express": "^2.9.7",
     "date-fns": "^2.0.0-beta.5",
     "express": "4.17.1",
-    "geospatialdraw": "https://github.com/connexta/geospatialdraw.git#62d6307c2fed6eec489bf99b9e8be50f9964225c",
+    "geospatialdraw": "https://github.com/connexta/geospatialdraw.git#9b8783d64da3e03b1b43d4c983185d4758b0d0d8",
     "golden-layout": "^1.5.9",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",

--- a/src/main/webapp/location/bbox.tsx
+++ b/src/main/webapp/location/bbox.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react'
+import { geometry, coordinates as coordinateEditor } from 'geospatialdraw'
+import { Filter, INTERSECTS, ANY_GEO, GEOMETRY } from './filter'
+import { geoToWKT } from './geo-to-wkt'
+import FormControl from '@material-ui/core/FormControl'
+import FormLabel from '@material-ui/core/FormLabel'
+import Point from './point'
+import Props from './geo-editor'
+import SpacedLinearContainer from '../spaced-linear-container'
+
+export const generateFilter = (geo: geometry.GeometryJSON): Filter => ({
+  type: INTERSECTS,
+  property: ANY_GEO,
+  value: {
+    type: GEOMETRY,
+    value: geoToWKT(geo),
+  },
+  geojson: geo,
+})
+
+const BBox: React.SFC<Props> = ({ value, onChange, coordinateUnit }) => {
+  const { id, bbox, properties } = coordinateEditor.geoToBBoxProps(value)
+  const [lowerRight, upperLeft] = coordinateEditor.bboxToCoordinatePair(bbox)
+  const containerDirection =
+    coordinateUnit === coordinateEditor.UTM ? 'row' : 'column'
+  const formControlStyle: any = {
+    display: 'flex',
+    flexDirection: containerDirection,
+  }
+  const formLabelStyle: any =
+    coordinateUnit === coordinateEditor.UTM
+      ? {
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          marginRight: '0.5em',
+        }
+      : {}
+  return (
+    <SpacedLinearContainer direction={containerDirection} spacing={2}>
+      <FormControl style={formControlStyle}>
+        <FormLabel style={formLabelStyle}>Upper Left</FormLabel>
+        <Point
+          coordinateUnit={coordinateUnit}
+          value={upperLeft}
+          onChange={update =>
+            onChange(
+              coordinateEditor.bboxPropsToGeo({
+                id,
+                bbox: coordinateEditor.coordinatePairToBBox([
+                  update,
+                  lowerRight,
+                ]),
+                properties,
+              })
+            )
+          }
+        />
+      </FormControl>
+      <FormControl style={formControlStyle}>
+        <FormLabel style={formLabelStyle}>Lower Right</FormLabel>
+        <Point
+          coordinateUnit={coordinateUnit}
+          value={lowerRight}
+          onChange={update =>
+            onChange(
+              coordinateEditor.bboxPropsToGeo({
+                id,
+                bbox: coordinateEditor.coordinatePairToBBox([
+                  update,
+                  upperLeft,
+                ]),
+                properties,
+              })
+            )
+          }
+        />
+      </FormControl>
+    </SpacedLinearContainer>
+  )
+}
+
+export default BBox

--- a/src/main/webapp/location/coordinate-list.tsx
+++ b/src/main/webapp/location/coordinate-list.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react'
+import { geometry, coordinates as coordinateEditor } from 'geospatialdraw'
+import Box from '@material-ui/core/Box'
+import ButtonGroup from '@material-ui/core/ButtonGroup'
+import Button from '@material-ui/core/Button'
+import RemoveIcon from '@material-ui/icons/Remove'
+import AddIcon from '@material-ui/icons/Add'
+import List from '@material-ui/core/List'
+import ListItem from '@material-ui/core/ListItem'
+import Point from './point'
+import Length from './length'
+import SpacedLinearContainer from '../spaced-linear-container'
+import CoordinateValue from './coordinate-value'
+
+type Props = {
+  coordinateList: [number, number][]
+  coordinateUnit: coordinateEditor.CoordinateUnit
+  buffer: number
+  bufferUnit: geometry.LengthUnit
+  onChange: (
+    coordinateList: [number, number][],
+    buffer: number,
+    bufferUnit: geometry.LengthUnit
+  ) => void
+}
+
+const CoordinateList: React.SFC<Props> = ({
+  coordinateList: initCoordinates,
+  coordinateUnit,
+  buffer,
+  bufferUnit,
+  onChange,
+}) => {
+  const {
+    lat,
+    lon,
+    coordinateList,
+    setSelectedIndex,
+    selectedIndex,
+    addCoordinateAfter,
+    deleteCoordinate,
+    setCoordinate,
+  } = coordinateEditor.useCoordinateList(initCoordinates, 0)
+  React.useEffect(
+    () => {
+      if (JSON.stringify(coordinateList) !== JSON.stringify(initCoordinates)) {
+        onChange(coordinateList, buffer, bufferUnit)
+      }
+    },
+    [coordinateList]
+  )
+  return (
+    <SpacedLinearContainer direction="column" spacing={1}>
+      <Point
+        value={{ lat, lon }}
+        coordinateUnit={coordinateUnit}
+        onChange={setCoordinate}
+      />
+      <Length
+        label="Buffer"
+        value={{ length: buffer, unit: bufferUnit }}
+        onChange={({ length, unit }) => onChange(coordinateList, length, unit)}
+      />
+      <Box>
+        <Box flexDirection="row" display="flex" justifyContent="flex-end">
+          <ButtonGroup>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={addCoordinateAfter}
+              title="Add Coordinate"
+              startIcon={<AddIcon />}
+            >
+              Add
+            </Button>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={deleteCoordinate}
+              title="Remove Coordinate"
+              startIcon={<RemoveIcon />}
+            >
+              Remove
+            </Button>
+          </ButtonGroup>
+        </Box>
+        <List>
+          {coordinateList.map(
+            ([coordinateLon, coordinateLat], index: number) => (
+              <ListItem
+                key={index}
+                button
+                selected={index === selectedIndex}
+                onClick={() => setSelectedIndex(index)}
+                title={`Select Coordinate #${index + 1}`}
+              >
+                <CoordinateValue
+                  lat={coordinateLat}
+                  lon={coordinateLon}
+                  unit={coordinateUnit}
+                />
+              </ListItem>
+            )
+          )}
+        </List>
+      </Box>
+    </SpacedLinearContainer>
+  )
+}
+
+export default CoordinateList

--- a/src/main/webapp/location/geolocation.stories.js
+++ b/src/main/webapp/location/geolocation.stories.js
@@ -2,18 +2,49 @@ import { action } from '@connexta/ace/@storybook/addon-actions'
 import { storiesOf } from '../@storybook/react'
 import React, { useState } from 'react'
 import PointRadius from './point-radius'
+import Line from './line'
+import Polygon from './polygon'
+import BBox from './bbox'
 import { geometry, coordinates as coordinateEditor } from 'geospatialdraw'
+import withCoordinateUnitTabs from './with-coordinate-unit-tabs'
 
 const stories = storiesOf('GeoLocation', module)
 stories.addDecorator(Story => <Story />)
 
-const pointRadiusGeo = geometry.makePointRadiusGeo(
-  'pointRadiusGeo',
-  45,
-  38,
-  600,
-  geometry.MILES
-)
+const editors = {
+  pointRadius: {
+    Editor: PointRadius,
+    geo: geometry.makePointRadiusGeo(
+      'pointRadiusGeo',
+      45,
+      38,
+      600,
+      geometry.MILES
+    ),
+  },
+  line: {
+    Editor: Line,
+    geo: geometry.makeLineGeo(
+      'lineGeo',
+      [[50, 50], [56, 20], [36, 30]],
+      50,
+      geometry.KILOMETERS
+    ),
+  },
+  polygon: {
+    Editor: Polygon,
+    geo: geometry.makePolygonGeo(
+      'polygonGeo',
+      [[50, 50], [56, 20], [36, 30]],
+      30,
+      geometry.NAUTICAL_MILES
+    ),
+  },
+  bbox: {
+    Editor: BBox,
+    geo: geometry.makeBBoxGeo('bboxGeo', [20, 30, 50, 50]),
+  },
+}
 
 const coordinateUnits = [
   coordinateEditor.LAT_LON,
@@ -22,17 +53,33 @@ const coordinateUnits = [
   coordinateEditor.UTM,
 ]
 
-coordinateUnits.forEach(coordinateUnit => {
-  stories.add(`point radius using ${coordinateUnit}`, () => {
-    const [geo, setGeo] = useState(pointRadiusGeo)
+Object.keys(editors).forEach(key => {
+  const editor = editors[key]
+  coordinateUnits.forEach(coordinateUnit => {
+    stories.add(`${key} using ${coordinateUnit}`, () => {
+      const [geo, setGeo] = useState(editor.geo)
+      return (
+        <editor.Editor
+          value={geo}
+          onChange={update => {
+            action('onChange')(update)
+            setGeo(update)
+          }}
+          coordinateUnit={coordinateUnit}
+        />
+      )
+    })
+  })
+  stories.add(`${key} with coordinate tabs`, () => {
+    const [geo, setGeo] = useState(editor.geo)
+    const Editor = withCoordinateUnitTabs(editor.Editor)
     return (
-      <PointRadius
+      <Editor
         value={geo}
         onChange={update => {
           action('onChange')(update)
           setGeo(update)
         }}
-        coordinateUnit={coordinateUnit}
       />
     )
   })

--- a/src/main/webapp/location/line.tsx
+++ b/src/main/webapp/location/line.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+import { geometry, coordinates as coordinateEditor } from 'geospatialdraw'
+import { Filter, DWITHIN, INTERSECTS, ANY_GEO, GEOMETRY } from './filter'
+import { geoToWKT } from './geo-to-wkt'
+import CoordinateList from './coordinate-list'
+import Props from './geo-editor'
+
+export const generateFilter = (geo: geometry.GeometryJSON): Filter => ({
+  type: (geo.properties.buffer || 0) > 0 ? DWITHIN : INTERSECTS,
+  property: ANY_GEO,
+  value: {
+    type: GEOMETRY,
+    value: geoToWKT(geo),
+  },
+  geojson: geo,
+})
+
+const Line: React.SFC<Props> = ({ value, onChange, coordinateUnit }) => {
+  const {
+    id,
+    properties,
+    coordinates,
+    buffer,
+    bufferUnit,
+  } = coordinateEditor.geoToLineProps(value)
+  return (
+    <CoordinateList
+      coordinateList={coordinates}
+      coordinateUnit={coordinateUnit}
+      buffer={buffer}
+      bufferUnit={bufferUnit}
+      onChange={(coordinateListValue, bufferValue, bufferUnitValue) =>
+        onChange(
+          coordinateEditor.linePropsToGeo({
+            id,
+            coordinates: coordinateListValue,
+            buffer: bufferValue,
+            bufferUnit: bufferUnitValue,
+            properties,
+          })
+        )
+      }
+    />
+  )
+}
+
+export default Line

--- a/src/main/webapp/location/point/point-dms.tsx
+++ b/src/main/webapp/location/point/point-dms.tsx
@@ -164,7 +164,9 @@ const PointDMS: React.SFC<Props> = ({ value, onChange }) => {
   ] = coordinateEditor.useDMSCoordinates(value)
   React.useEffect(
     () => {
-      onChange(coordinates)
+      if (value.lat !== coordinates.lat || value.lon !== coordinates.lon) {
+        onChange(coordinates)
+      }
     },
     [coordinates.lat, coordinates.lon]
   )

--- a/src/main/webapp/location/point/point-usng.tsx
+++ b/src/main/webapp/location/point/point-usng.tsx
@@ -15,7 +15,9 @@ const PointUSNG: React.SFC<Props> = ({ value, onChange }) => {
   ] = coordinateEditor.useUSNGCoordinates(value)
   React.useEffect(
     () => {
-      onChange(coordinates)
+      if (value.lat !== coordinates.lat || value.lon !== coordinates.lon) {
+        onChange(coordinates)
+      }
     },
     [coordinates.lat, coordinates.lon]
   )

--- a/src/main/webapp/location/point/point-utm.tsx
+++ b/src/main/webapp/location/point/point-utm.tsx
@@ -31,7 +31,9 @@ const PointUTM: React.SFC<Props> = ({ value, onChange }) => {
   const { northing, easting, zone, hemisphere } = utm
   React.useEffect(
     () => {
-      onChange(coordinates)
+      if (value.lat !== coordinates.lat || value.lon !== coordinates.lon) {
+        onChange(coordinates)
+      }
     },
     [coordinates.lat, coordinates.lon]
   )

--- a/src/main/webapp/location/polygon.tsx
+++ b/src/main/webapp/location/polygon.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react'
+import { geometry, coordinates as coordinateEditor } from 'geospatialdraw'
+import { Filter, DWITHIN, INTERSECTS, ANY_GEO, GEOMETRY } from './filter'
+import { geoToWKT } from './geo-to-wkt'
+import CoordinateList from './coordinate-list'
+import Props from './geo-editor'
+
+export const generateFilter = (geo: geometry.GeometryJSON): Filter => ({
+  type: (geo.properties.buffer || 0) > 0 ? DWITHIN : INTERSECTS,
+  property: ANY_GEO,
+  value: {
+    type: GEOMETRY,
+    value: geoToWKT(geo),
+  },
+  geojson: geo,
+})
+
+const Polygon: React.SFC<Props> = ({ value, onChange, coordinateUnit }) => {
+  const {
+    id,
+    properties,
+    coordinates,
+    buffer,
+    bufferUnit,
+  } = coordinateEditor.geoToPolygonProps(value)
+  return (
+    <CoordinateList
+      coordinateList={coordinates}
+      coordinateUnit={coordinateUnit}
+      buffer={buffer}
+      bufferUnit={bufferUnit}
+      onChange={(coordinateListValue, bufferValue, bufferUnitValue) =>
+        onChange(
+          coordinateEditor.polygonPropsToGeo({
+            id,
+            coordinates: coordinateListValue,
+            buffer: bufferValue,
+            bufferUnit: bufferUnitValue,
+            properties,
+          })
+        )
+      }
+    />
+  )
+}
+
+export default Polygon

--- a/src/main/webapp/location/with-coordinate-unit-tabs.tsx
+++ b/src/main/webapp/location/with-coordinate-unit-tabs.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { geometry, coordinates as coordinateEditor } from 'geospatialdraw'
+import EditorProps from './geo-editor'
+import Tab from '@material-ui/core/Tab'
+import Tabs from '@material-ui/core/Tabs'
+import SpacedLinearContainer from '../spaced-linear-container'
+
+type Props = {
+  value: geometry.GeometryJSON
+  onChange: (geo: geometry.GeometryJSON) => void
+}
+
+type OutputComponent = React.SFC<Props>
+type EditorComponent = React.ComponentType<EditorProps>
+
+const tabMap: coordinateEditor.CoordinateUnit[] = [
+  coordinateEditor.LAT_LON,
+  coordinateEditor.LAT_LON_DMS,
+  coordinateEditor.USNG,
+  coordinateEditor.UTM,
+]
+
+const defaultTab = 0
+
+const withCoordinateUnitTabs = (Editor: EditorComponent): OutputComponent => ({
+  value,
+  onChange,
+}) => {
+  const [tab, setTab] = React.useState(defaultTab)
+  return (
+    <SpacedLinearContainer direction="column" spacing={1}>
+      <Tabs
+        value={tab}
+        onChange={(_, index) => setTab(index)}
+        indicatorColor="primary"
+        textColor="primary"
+        variant="fullWidth"
+      >
+        <Tab label="Lat / Lon (DD)" />
+        <Tab label="Lat / Lon (DMS)" />
+        <Tab label="USNG / MGRS" />
+        <Tab label="UTM / UPS" />
+      </Tabs>
+      <Editor value={value} onChange={onChange} coordinateUnit={tabMap[tab]} />
+    </SpacedLinearContainer>
+  )
+}
+
+export default withCoordinateUnitTabs

--- a/yarn.lock
+++ b/yarn.lock
@@ -7692,9 +7692,9 @@ geojson-rbush@2.1.0:
     "@turf/meta" "*"
     rbush "*"
 
-"geospatialdraw@https://github.com/connexta/geospatialdraw.git#62d6307c2fed6eec489bf99b9e8be50f9964225c":
+"geospatialdraw@https://github.com/connexta/geospatialdraw.git#9b8783d64da3e03b1b43d4c983185d4758b0d0d8":
   version "0.4.0"
-  resolved "https://github.com/connexta/geospatialdraw.git#62d6307c2fed6eec489bf99b9e8be50f9964225c"
+  resolved "https://github.com/connexta/geospatialdraw.git#9b8783d64da3e03b1b43d4c983185d4758b0d0d8"
   dependencies:
     "@turf/turf" "5.1.6"
     lodash.clonedeep "4.5.0"


### PR DESCRIPTION
Added location input for line, polygon, and bounding box using GeospatialDraw.

GeospatialDraw Revelio branch: https://github.com/connexta/geospatialdraw/tree/revelio

Screenshots:
<img width="1171" alt="Screen Shot 2019-11-26 at 11 36 36 AM" src="https://user-images.githubusercontent.com/9195522/69653649-8f38bb80-1041-11ea-83e4-f7145071477f.png">
<img width="313" alt="Screen Shot 2019-11-26 at 11 37 14 AM" src="https://user-images.githubusercontent.com/9195522/69653650-8f38bb80-1041-11ea-9cb6-7e4e23b58c5a.png">
<img width="313" alt="Screen Shot 2019-11-26 at 11 37 28 AM" src="https://user-images.githubusercontent.com/9195522/69653651-8f38bb80-1041-11ea-8ef5-a326f1c9ff8b.png">
<img width="314" alt="Screen Shot 2019-11-26 at 11 37 35 AM" src="https://user-images.githubusercontent.com/9195522/69653652-8f38bb80-1041-11ea-9cef-13e67654ba4f.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 04 AM" src="https://user-images.githubusercontent.com/9195522/69653653-8f38bb80-1041-11ea-8cb0-7ef4a619fb22.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 10 AM" src="https://user-images.githubusercontent.com/9195522/69653654-8f38bb80-1041-11ea-81cc-fae52306cc88.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 16 AM" src="https://user-images.githubusercontent.com/9195522/69653655-8fd15200-1041-11ea-85fe-50f95e05769b.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 19 AM" src="https://user-images.githubusercontent.com/9195522/69653656-8fd15200-1041-11ea-8d90-5bdfaffd4c10.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 23 AM" src="https://user-images.githubusercontent.com/9195522/69653657-8fd15200-1041-11ea-878d-7eaab31b754f.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 26 AM" src="https://user-images.githubusercontent.com/9195522/69653658-8fd15200-1041-11ea-90f3-b5c19f2f9367.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 29 AM" src="https://user-images.githubusercontent.com/9195522/69653659-8fd15200-1041-11ea-8624-4098aa34b1ef.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 32 AM" src="https://user-images.githubusercontent.com/9195522/69653660-8fd15200-1041-11ea-87a0-1abe424bd3c6.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 34 AM" src="https://user-images.githubusercontent.com/9195522/69653661-9069e880-1041-11ea-80b1-5a31bdb077bd.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 40 AM" src="https://user-images.githubusercontent.com/9195522/69653662-9069e880-1041-11ea-8f49-924c62d9ebc2.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 42 AM" src="https://user-images.githubusercontent.com/9195522/69653664-9069e880-1041-11ea-9bb9-8b3fdabbb399.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 46 AM" src="https://user-images.githubusercontent.com/9195522/69653665-9069e880-1041-11ea-843d-62e5933745d2.png">
<img width="749" alt="Screen Shot 2019-11-26 at 11 38 51 AM" src="https://user-images.githubusercontent.com/9195522/69653666-9069e880-1041-11ea-81f0-0b212fb45c71.png">
