### PR TITLE
Base64 and date fix

### DIFF
--- a/src/main/java/org/codice/jsonrpc/JsonRpcHttpServlet.java
+++ b/src/main/java/org/codice/jsonrpc/JsonRpcHttpServlet.java
@@ -12,7 +12,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class JsonRpcHttpServlet extends HttpServlet {
-  private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+  private static final Gson GSON =
+      new GsonBuilder().disableHtmlEscaping().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").create();
 
   private Method method;
 


### PR DESCRIPTION
- Binary metacard attributes are now base64 encoded instead of a list of integers
- Added iso8601 date formatting for GSON