### PR TITLE
Fix SSR rendering by sharing the resolver context.

### DIFF
--- a/src/main/graphql-server/helpers/renderer.js
+++ b/src/main/graphql-server/helpers/renderer.js
@@ -20,8 +20,7 @@ module.exports = async (req, res, next) => {
   const path = req.originalUrl.replace(ROOT_PATH, '')
   try {
     if (hasPath(path)) {
-      const { originalUrl, clientBundle = retrieveClientBundle() } = req
-      const html = await executeSSR(originalUrl, clientBundle)
+      const html = await executeSSR(req)
       res.end(html)
     } else {
       next()
@@ -35,9 +34,11 @@ module.exports = async (req, res, next) => {
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-const executeSSR = async (originalUrl, clientBundle) => {
+const executeSSR = async req => {
+  const { originalUrl, clientBundle = retrieveClientBundle() } = req
+
   const sheets = new ServerStyleSheets()
-  const client = createServerApollo()
+  const client = createServerApollo({ req })
 
   const App = sheets.collect(
     <ApolloProvider client={client}>

--- a/src/main/graphql-server/middleware.js
+++ b/src/main/graphql-server/middleware.js
@@ -1,8 +1,7 @@
 const { ApolloServer } = require('apollo-server-express')
 const express = require('express')
 const renderer = require('./helpers/renderer')
-import createRpcClient from '../webapp/intrigue-api/rpc'
-const fetch = require('../webapp/intrigue-api/fetch')
+
 const {
   resolvers,
   typeDefs,
@@ -24,48 +23,7 @@ const server = new ApolloServer({
       Authorization,
     },
   },
-  context: args => {
-    const { req } = args
-
-    const { authorization = '' } = req.headers
-    const universalFetch = (url, opts = {}) => {
-      return fetch(url, {
-        ...opts,
-        headers: {
-          ...opts.headers,
-          authorization,
-        },
-      })
-    }
-    const request = createRpcClient(universalFetch)
-
-    const catalogMethods = {
-      create: 'ddf.catalog/create',
-      query: 'ddf.catalog/query',
-      update: 'ddf.catalog/update',
-      delete: 'ddf.catalog/delete',
-      getSourceIds: 'ddf.catalog/getSourceIds',
-      getSourceInfo: 'ddf.catalog/getSourceInfo',
-    }
-    const enumerationMethods = {
-      getAllEnumerations: 'ddf.enumerations/all',
-    }
-
-    const catalog = Object.keys(catalogMethods).reduce((catalog, method) => {
-      catalog[method] = params => request(catalogMethods[method], params)
-      return catalog
-    }, {})
-
-    const enumerations = Object.keys(enumerationMethods).reduce(
-      (enumerations, method) => {
-        enumerations[method] = params =>
-          request(enumerationMethods[method], params)
-        return enumerations
-      },
-      {}
-    )
-    return { catalog, fetch: universalFetch, enumerations, ...context(args) }
-  },
+  context,
 })
 
 // Useful for getting example request/responses from the graphql endpoint.

--- a/src/main/webapp/intrigue-api/context.js
+++ b/src/main/webapp/intrigue-api/context.js
@@ -1,0 +1,47 @@
+import createRpcClient from './rpc'
+import fetch from './fetch'
+
+const context = args => {
+  const { req } = args
+
+  const { authorization = '' } = req.headers
+  const universalFetch = (url, opts = {}) => {
+    return fetch(url, {
+      ...opts,
+      headers: {
+        ...opts.headers,
+        authorization,
+      },
+    })
+  }
+  const request = createRpcClient(universalFetch)
+
+  const catalogMethods = {
+    create: 'ddf.catalog/create',
+    query: 'ddf.catalog/query',
+    update: 'ddf.catalog/update',
+    delete: 'ddf.catalog/delete',
+    getSourceIds: 'ddf.catalog/getSourceIds',
+    getSourceInfo: 'ddf.catalog/getSourceInfo',
+  }
+  const enumerationMethods = {
+    getAllEnumerations: 'ddf.enumerations/all',
+  }
+
+  const catalog = Object.keys(catalogMethods).reduce((catalog, method) => {
+    catalog[method] = params => request(catalogMethods[method], params)
+    return catalog
+  }, {})
+
+  const enumerations = Object.keys(enumerationMethods).reduce(
+    (enumerations, method) => {
+      enumerations[method] = params =>
+        request(enumerationMethods[method], params)
+      return enumerations
+    },
+    {}
+  )
+  return { catalog, fetch: universalFetch, enumerations }
+}
+
+export default context

--- a/src/main/webapp/intrigue-api/schema.js
+++ b/src/main/webapp/intrigue-api/schema.js
@@ -1,4 +1,5 @@
-const { mergeDeep } = require('immutable')
+import { mergeDeep } from 'immutable'
+import context from './context'
 
 const ensureArray = value => {
   if (value === undefined) {
@@ -37,7 +38,7 @@ const mergeModules = (a, b) => {
   }
 }
 
-const baseTypeDefs = `
+const typeDefs = `
   # Arbitrary Json
   scalar Json
   # Binary content embedded as a base64 String
@@ -58,8 +59,8 @@ const baseTypeDefs = `
   }
 `
 
-const { resolvers, typeDefs = [], context } = [
-  { resolvers: {}, typeDefs: baseTypeDefs },
+export default [
+  { resolvers: {}, typeDefs, context },
   require('./metacards/metacards')(),
   require('./location/location'),
   require('./user/user'),
@@ -67,9 +68,3 @@ const { resolvers, typeDefs = [], context } = [
   require('./metacard-types/metacard-types'),
   require('./system-properties/system-properties'),
 ].reduce(mergeModules)
-
-module.exports = {
-  resolvers,
-  typeDefs,
-  context,
-}


### PR DESCRIPTION
The resolver context sets up all the clients (fetch/jsonrpc) to interact
with DDF. When using the schema link, we need to ensure resolvers still
get clients or they won't be able to communicate with DDF. Those clients
also need access to the current HTTP request to pull auth info from
headers.