### PR TITLE
Prevent font flash by preventing SSR CSS escaping

### DIFF
--- a/src/main/graphql-server/helpers/renderer.js
+++ b/src/main/graphql-server/helpers/renderer.js
@@ -57,7 +57,10 @@ const executeSSR = async req => {
               __html: `window.__APOLLO_STATE__ = ${JSON.stringify(state)}`,
             }}
           />
-          <style id="css-server-side">${css}</style>
+          <style
+            id="css-server-side"
+            dangerouslySetInnerHTML={{ __html: css }}
+          />
         </head>
         <body style={{ margin: 0 }}>
           <div id="root" dangerouslySetInnerHTML={{ __html: content }} />


### PR DESCRIPTION
When the CSS was being rendered into the style tag, it was being HTML
encoded producing invalid CSS. `dangerouslySetInnerHTML` can be used to
prevent this.