### PR TITLE
Fix build performance regression

### DIFF
--- a/src/main/webapp/query-filters/filter-input/boolean-filter.tsx
+++ b/src/main/webapp/query-filters/filter-input/boolean-filter.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import { QueryFilterProps } from '../filter/individual-filter'
-import { Box, Switch, Button } from '@material-ui/core'
+
+import Box from '@material-ui/core/Box'
+import Switch from '@material-ui/core/Switch'
+import Button from '@material-ui/core/Button'
+
 import { Map } from 'immutable'
 
 export const comparatorOptions = ['=', 'IS NULL']

--- a/src/main/webapp/query-filters/filter-input/location-filter.tsx
+++ b/src/main/webapp/query-filters/filter-input/location-filter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { QueryFilterProps } from '../filter/individual-filter'
-import { Box } from '@material-ui/core'
+import Box from '@material-ui/core/Box'
 import { makeDefaultSearchGeo } from '../filter'
 import { filterComponentStyle } from '../filter/filter-utils'
 import { Location, geoToFilter } from '../../location'

--- a/src/main/webapp/query-filters/filter-input/number-filter.tsx
+++ b/src/main/webapp/query-filters/filter-input/number-filter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { QueryFilterProps } from '../filter/individual-filter'
-import { TextField, Box } from '@material-ui/core'
+import TextField from '@material-ui/core/TextField'
+import Box from '@material-ui/core/Box'
 import { Map, getIn } from 'immutable'
 import { useFilterContext } from '../filter-context'
 

--- a/src/main/webapp/query-filters/filter-input/text-filter.tsx
+++ b/src/main/webapp/query-filters/filter-input/text-filter.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { QueryFilterProps } from '../filter/individual-filter'
-import { TextField, Box } from '@material-ui/core'
+import TextField from '@material-ui/core/TextField'
+import Box from '@material-ui/core/Box'
 import { Map, getIn, List } from 'immutable'
 import { useFilterContext } from '../filter-context'
 import Autocomplete from '@material-ui/lab/Autocomplete'

--- a/src/main/webapp/query-filters/filter/attribute-dropdown.tsx
+++ b/src/main/webapp/query-filters/filter/attribute-dropdown.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import Select from '@material-ui/lab/Autocomplete'
-import { Box } from '@material-ui/core'
+import Box from '@material-ui/core/Box'
 import TextField from '@material-ui/core/TextField'
 import { useFilterContext } from '../filter-context'
 

--- a/src/main/webapp/query-filters/filter/comparator-dropdown.tsx
+++ b/src/main/webapp/query-filters/filter/comparator-dropdown.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import useAnchorEl from '../../react-hooks/use-anchor-el'
-import { Button, Box, Popover, MenuItem } from '@material-ui/core'
-import { ArrowDropDown as DropDownIcon } from '@material-ui/icons'
+import Button from '@material-ui/core/Button'
+import Box from '@material-ui/core/Box'
+import Popover from '@material-ui/core/Popover'
+import MenuItem from '@material-ui/core/MenuItem'
+import DropDownIcon from '@material-ui/icons/ArrowDropDown'
 import { Map } from 'immutable'
 import { useFilterContext } from '../filter-context'
 

--- a/src/main/webapp/query-filters/filter/filter-group.tsx
+++ b/src/main/webapp/query-filters/filter/filter-group.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
 import IndividualFilter, { QueryFilter } from './individual-filter'
-import { Box, Button, Typography } from '@material-ui/core'
-import { Add } from '@material-ui/icons'
+import Box from '@material-ui/core/Box'
+import Button from '@material-ui/core/Button'
+import Typography from '@material-ui/core/Typography'
+import Add from '@material-ui/icons/Add'
 import {
   defaultFilter,
   filterHeaderButtonStyle,

--- a/src/main/webapp/query-filters/filter/filter-utils.tsx
+++ b/src/main/webapp/query-filters/filter/filter-utils.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import { Box } from '@material-ui/core'
+import Box from '@material-ui/core/Box'
 import Fab from '@material-ui/core/Fab'
-import { Remove } from '@material-ui/icons'
+import Remove from '@material-ui/icons/Remove'
 import { MetacardType } from './dummyDefinitions'
 import { makeDefaultSearchGeo } from './search-geo-factory'
 

--- a/src/main/webapp/query-filters/filter/index.tsx
+++ b/src/main/webapp/query-filters/filter/index.tsx
@@ -7,7 +7,9 @@ import FilterGroup, { FilterGroupType, FilterGroupProps } from './filter-group'
 import { FilterContext } from '../filter-context'
 import { sampleMetacardTypes } from './dummyDefinitions'
 import useMetacardTypes from '../../react-hooks/use-metacard-types'
-import { Paper, LinearProgress, Typography } from '@material-ui/core'
+import Paper from '@material-ui/core/Paper'
+import LinearProgress from '@material-ui/core/LinearProgress'
+import Typography from '@material-ui/core/Typography'
 export { makeDefaultSearchGeo, makeSearchGeoId } from './search-geo-factory'
 
 const useApolloFallback = require('../../react-hooks/use-apollo-fallback')

--- a/src/main/webapp/query-filters/filter/individual-filter.tsx
+++ b/src/main/webapp/query-filters/filter/individual-filter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Box } from '@material-ui/core'
+import Box from '@material-ui/core/Box'
 import {
   withDivider,
   withRemoveButton,

--- a/src/main/webapp/query-filters/filter/operator.tsx
+++ b/src/main/webapp/query-filters/filter/operator.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import useAnchorEl from '../../react-hooks/use-anchor-el'
-import { Button, Popover, MenuItem, Typography } from '@material-ui/core'
-import { ArrowDropDown } from '@material-ui/icons'
+import Button from '@material-ui/core/Button'
+import Popover from '@material-ui/core/Popover'
+import MenuItem from '@material-ui/core/MenuItem'
+import Typography from '@material-ui/core/Typography'
+import ArrowDropDown from '@material-ui/icons/ArrowDropDown'
 import { filterHeaderButtonStyle } from './filter-utils'
 
 const operators = ['AND', 'OR', 'NOT AND', 'NOT OR']

--- a/src/main/webapp/search-forms/editor.tsx
+++ b/src/main/webapp/search-forms/editor.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react'
 import Filter from '../query-filters/filter'
-import { Box, Paper, TextField, Divider } from '@material-ui/core'
+
+import Box from '@material-ui/core/Box'
+import Paper from '@material-ui/core/Paper'
+import TextField from '@material-ui/core/TextField'
+import Divider from '@material-ui/core/Divider'
+
 import loadable from 'react-loadable'
 import { memo } from 'react'
 

--- a/src/main/webapp/search-forms/route.tsx
+++ b/src/main/webapp/search-forms/route.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
-import { LinearProgress, Dialog } from '@material-ui/core'
+
+import LinearProgress from '@material-ui/core/LinearProgress'
+import Dialog from '@material-ui/core/Dialog'
+
 const {
   IndexCards,
   AddCardItem,


### PR DESCRIPTION
Importing all of material-ui, while it might get dead code eliminated,
still adds a large amount of overhead to our build.