### PR TITLE
Fixed bug with loading point radius geometry from DDF.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "compression": "^1.7.4",
     "date-fns": "^2.0.0-beta.5",
     "express": "4.17.1",
-    "geospatialdraw": "https://github.com/connexta/geospatialdraw.git#ce9830eeca9e1400734eb3c87eaaff20fbc611e0",
+    "geospatialdraw": "https://github.com/connexta/geospatialdraw.git#c330407bda2442a983b42e9f1afbb4575c1e21fc",
     "golden-layout": "^1.5.9",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",

--- a/src/main/webapp/basic-search-helper.js
+++ b/src/main/webapp/basic-search-helper.js
@@ -1,4 +1,4 @@
-import { geometry, shapes } from 'geospatialdraw'
+import { geometry } from 'geospatialdraw'
 import { geoToFilter } from './location'
 import { makeSearchGeoId } from './query-filters/filter'
 const { Map, Set, fromJS } = require('immutable')
@@ -45,12 +45,8 @@ const unitsMap = Map(fromJS(relativeUnits))
 
 const datatypeProperties = ['metadata-content-type', 'datatype']
 
-const shapeDetector = new shapes.ShapeDetector()
-
-const parseGeoFilter = (filter = {}) => {
-  const shape = shapeDetector.shapeFromGeoJSON(filter.geojson)
-  return geometry.makeGeometry(makeSearchGeoId(), filter.geojson, '', shape)
-}
+const parseGeoFilter = (filter = {}) =>
+  geometry.geoJSONToGeometryJSON(makeSearchGeoId(), filter.geojson)
 
 export const fromFilterTree = filterTree => {
   return filterTree.filters

--- a/src/main/webapp/location/filter.tsx
+++ b/src/main/webapp/location/filter.tsx
@@ -22,7 +22,10 @@ export type Filter = {
 }
 
 export const geoToFilter = (geo: geometry.GeometryJSON): Filter => ({
-  type: (geo.properties.buffer || 0) > 0 ? DWITHIN : INTERSECTS,
+  type:
+    geo.properties.buffer && geo.properties.buffer.width > 0
+      ? DWITHIN
+      : INTERSECTS,
   property: ANY_GEO,
   value: {
     type: GEOMETRY,

--- a/src/main/webapp/location/geo-to-wkt.tsx
+++ b/src/main/webapp/location/geo-to-wkt.tsx
@@ -29,8 +29,10 @@ export const wktToGeo = ({
     geometry: geojsonFormatter.writeGeometryObject(geo),
     properties: {
       ...properties,
-      buffer,
-      bufferUnit,
+      buffer: {
+        width: buffer,
+        unit: bufferUnit,
+      },
     },
   })
 }

--- a/src/main/webapp/location/keyword/index.spec.js
+++ b/src/main/webapp/location/keyword/index.spec.js
@@ -220,19 +220,21 @@ describe('<Keyword />', () => {
           ...value,
           properties: {
             ...value.properties,
-            buffer: 50,
-            bufferUnit: geometry.MILES,
+            buffer: {
+              width: 50,
+              unit: geometry.MILES,
+            },
           },
         })
         expect(changes.length).to.equal(2)
         expect(changes[0].properties.keyword).to.equal('test')
         expect(changes[0].properties.keywordId).to.equal('test-id')
-        expect(changes[0].properties.buffer).to.equal(0)
-        expect(changes[0].properties.bufferUnit).to.equal(geometry.METERS)
+        expect(changes[0].properties.buffer.width).to.equal(0)
+        expect(changes[0].properties.buffer.unit).to.equal(geometry.METERS)
         expect(changes[1].properties.keyword).to.equal('test')
         expect(changes[1].properties.keywordId).to.equal('test-id')
-        expect(changes[1].properties.buffer).to.equal(50)
-        expect(changes[1].properties.bufferUnit).to.equal(geometry.MILES)
+        expect(changes[1].properties.buffer.width).to.equal(50)
+        expect(changes[1].properties.buffer.unit).to.equal(geometry.MILES)
       })
     })
   })

--- a/src/main/webapp/location/location.stories.js
+++ b/src/main/webapp/location/location.stories.js
@@ -275,8 +275,10 @@ stories.add(`location with keyword`, () => {
       properties: {
         keyword: 'Italy',
         keywordId: '1dc06d71-dc20-44d5-b211-de33816071c1',
-        buffer: 50,
-        bufferUnit: geometry.MILES,
+        buffer: {
+          width: 50,
+          unit: geometry.MILES,
+        },
       },
     })
   )

--- a/src/main/webapp/maps/cluster-map.stories.js
+++ b/src/main/webapp/maps/cluster-map.stories.js
@@ -34,8 +34,10 @@ stories.add('render clusters', () => {
       properties: {
         id: '',
         color: '',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
         shape: 'Polygon',
       },
       bbox: [
@@ -56,8 +58,10 @@ stories.add('render clusters', () => {
       properties: {
         id: '',
         color: '',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
         shape: 'Bounding Box',
       },
       geometry: {
@@ -82,8 +86,10 @@ stories.add('render clusters', () => {
       properties: {
         id: '',
         color: '',
-        buffer: 979.4785955831757,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 979.4785955831757,
+          unit: 'meters',
+        },
         shape: 'Point Radius',
       },
       bbox: [
@@ -114,8 +120,10 @@ stories.add('render clusters', () => {
       properties: {
         id: '',
         color: '',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
         shape: 'Line',
       },
       bbox: [
@@ -134,8 +142,10 @@ stories.add('render clusters', () => {
       properties: {
         id: '',
         color: '',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
         shape: 'Point',
       },
       bbox: [-77.028019, 38.898326, -77.028019, 38.898326],
@@ -149,8 +159,10 @@ stories.add('render clusters', () => {
       properties: {
         id: '',
         color: '',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
         shape: 'Point',
       },
       bbox: [-77.021717, 38.898818, -77.021717, 38.898818],
@@ -164,8 +176,10 @@ stories.add('render clusters', () => {
       properties: {
         id: '',
         color: '',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
         shape: 'Point',
       },
       bbox: [-77.032099, 38.90135, -77.032099, 38.90135],

--- a/src/main/webapp/maps/map-style.js
+++ b/src/main/webapp/maps/map-style.js
@@ -160,7 +160,8 @@ const GENERIC_DRAWING_STYLE = feature => [
     }),
     ...(feature.getGeometry() &&
     feature.getGeometry().getType() === 'Point' &&
-    feature.get('buffer') > 0
+    feature.get('buffer') &&
+    feature.get('buffer').width > 0
       ? {}
       : {
           image: new Circle({

--- a/src/main/webapp/maps/world-map.stories.js
+++ b/src/main/webapp/maps/world-map.stories.js
@@ -81,8 +81,10 @@ stories.add('render geometries', () => {
         shape: 'Polygon',
         id: 'shape1',
         color: '#a020f0',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
       },
       bbox: [
         -77.39377564457455,
@@ -127,8 +129,10 @@ stories.add('render geometries', () => {
         shape: 'Polygon',
         id: 'shape2',
         color: '#ffd700',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
       },
       bbox: [
         -50.555500573327464,
@@ -165,8 +169,10 @@ stories.add('render geometries', () => {
         shape: 'Polygon',
         id: 'shape3',
         color: '#ff00ff',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
       },
       bbox: [
         129.05907305960878,
@@ -231,8 +237,10 @@ stories.add('render geometries', () => {
         shape: 'Polygon',
         id: 'shape4',
         color: '#ffff00',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
       },
       bbox: [
         111.19816697657915,
@@ -251,8 +259,10 @@ stories.add('render geometries', () => {
         shape: 'Point Radius',
         id: 'shape5',
         color: '#a52a2a',
-        buffer: 86.22498402406272,
-        bufferUnit: 'kilometers',
+        buffer: {
+          width: 86.22498402406272,
+          unit: 'kilometers',
+        },
       },
       bbox: [
         1.591858105761676,
@@ -271,8 +281,10 @@ stories.add('render geometries', () => {
         id: 'shape6',
         color: '#0000ff',
         shape: 'Point',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
       },
       bbox: [
         -77.03353449715513,
@@ -291,8 +303,10 @@ stories.add('render geometries', () => {
         shape: 'Point',
         id: 'shape7',
         color: '#ff0000',
-        buffer: 0,
-        bufferUnit: 'meters',
+        buffer: {
+          width: 0,
+          unit: 'meters',
+        },
       },
       bbox: [
         37.631401597084825,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7895,9 +7895,9 @@ geojson-rbush@2.1.0:
     "@turf/meta" "*"
     rbush "*"
 
-"geospatialdraw@https://github.com/connexta/geospatialdraw.git#ce9830eeca9e1400734eb3c87eaaff20fbc611e0":
+"geospatialdraw@https://github.com/connexta/geospatialdraw.git#c330407bda2442a983b42e9f1afbb4575c1e21fc":
   version "0.4.0"
-  resolved "https://github.com/connexta/geospatialdraw.git#ce9830eeca9e1400734eb3c87eaaff20fbc611e0"
+  resolved "https://github.com/connexta/geospatialdraw.git#c330407bda2442a983b42e9f1afbb4575c1e21fc"
   dependencies:
     "@turf/turf" "5.1.6"
     lodash.clonedeep "4.5.0"


### PR DESCRIPTION
Loading point radius search geometry from DDF causes the Workspace to crash. This was due to a mismatch between the format for buffer values in DDF an GeospatialDraw. This fix updates GeospatialDraw to match DDF resolving the error.