### PR TITLE
Fixed Draw button in QuerySelector popup

### DIFF
--- a/src/main/webapp/basic-search-helper.js
+++ b/src/main/webapp/basic-search-helper.js
@@ -1,6 +1,6 @@
 import { geoJSONToGeometryJSON } from 'geospatialdraw/bin/geometry/utilities'
 import { geoToFilter } from './location'
-import { makeSearchGeoId } from './query-filters/filter'
+import { makeSearchGeoIdForFilter } from './query-filters/filter'
 const { Map, Set, fromJS } = require('immutable')
 export const APPLY_TO_KEY = 'applyTo'
 export const DATATYPES_KEY = 'datatypes'
@@ -46,7 +46,7 @@ const unitsMap = Map(fromJS(relativeUnits))
 const datatypeProperties = ['metadata-content-type', 'datatype']
 
 const parseGeoFilter = (filter = {}) =>
-  geoJSONToGeometryJSON(makeSearchGeoId(), filter.geojson)
+  geoJSONToGeometryJSON(makeSearchGeoIdForFilter(filter.value), filter.geojson)
 
 export const fromFilterTree = filterTree => {
   return filterTree.filters

--- a/src/main/webapp/location/with-draw-button.tsx
+++ b/src/main/webapp/location/with-draw-button.tsx
@@ -61,7 +61,7 @@ const withDrawButton = (
   const editorOnChange = (geo: GeometryJSON) => {
     setDrawState({
       geo,
-      active: true,
+      active: drawState.active,
       shape,
     })
     onChange(geo)

--- a/src/main/webapp/query-filters/filter-input/location-filter.tsx
+++ b/src/main/webapp/query-filters/filter-input/location-filter.tsx
@@ -3,7 +3,7 @@ import { QueryFilterProps } from '../filter/individual-filter'
 import { makeDefaultSearchGeo } from '../filter'
 import { Location, geoToFilter } from '../../location'
 import AttributeDropdown from '../filter/attribute-dropdown'
-import { makeSearchGeoId } from '../filter/search-geo-factory'
+import { makeSearchGeoIdForFilter } from '../filter/search-geo-factory'
 import { wktToGeo } from '../../location/geo-to-wkt'
 
 const getGeojson = (filter: QueryFilterProps['filter']) => {
@@ -12,7 +12,7 @@ const getGeojson = (filter: QueryFilterProps['filter']) => {
   if (filter.value) {
     return wktToGeo({
       wkt: filter.value,
-      id: makeSearchGeoId(),
+      id: makeSearchGeoIdForFilter(filter.value),
       buffer: filter.distance || 0,
       bufferUnit: 'meters',
     })

--- a/src/main/webapp/query-filters/filter/index.tsx
+++ b/src/main/webapp/query-filters/filter/index.tsx
@@ -4,7 +4,10 @@ import IndividualFilter, {
   QueryFilterProps,
 } from './individual-filter'
 import FilterGroup, { FilterGroupType, FilterGroupProps } from './filter-group'
-export { makeDefaultSearchGeo, makeSearchGeoId } from './search-geo-factory'
+export {
+  makeDefaultSearchGeo,
+  makeSearchGeoIdForFilter,
+} from './search-geo-factory'
 
 export const isFilterGroup = (
   object: QueryFilter | FilterGroupType

--- a/src/main/webapp/query-filters/filter/search-geo-factory.tsx
+++ b/src/main/webapp/query-filters/filter/search-geo-factory.tsx
@@ -1,6 +1,14 @@
 import { makeEmptyGeometry } from 'geospatialdraw/bin/geometry/utilities'
 import { LINE } from 'geospatialdraw/bin/shapes/shape'
 
-export const makeSearchGeoId = (): string => `search-geo-${Math.random()}`
+const idCache: Map<string, string> = new Map()
+
+const makeSearchGeoId = (): string => `search-geo-${Math.random()}`
+export const makeSearchGeoIdForFilter = (filterValue: string): string => {
+  if (!idCache.has(filterValue)) {
+    idCache.set(filterValue, makeSearchGeoId())
+  }
+  return idCache.get(filterValue) || ''
+}
 export const makeDefaultSearchGeo = () =>
   makeEmptyGeometry(makeSearchGeoId(), LINE)

--- a/src/main/webapp/workspaces/query-selector.js
+++ b/src/main/webapp/workspaces/query-selector.js
@@ -1,13 +1,14 @@
 import Button from '@material-ui/core/Button'
 import Popover from '@material-ui/core/Popover'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
-import React from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import {
   Actions,
   DeleteAction,
   EditAction,
   IndexCardItem,
 } from '../index-cards'
+const { useDrawInterface } = require('../react-hooks')
 
 const useOpenClose = props => {
   const [anchorEl, setAnchorEl] = React.useState(null)
@@ -30,9 +31,26 @@ const useOpenClose = props => {
 const QueryCard = props => {
   const { title, onClick, QueryEditor, query } = props
   const [anchorEl, open, handleOpen, handleClose] = useOpenClose(props)
-
+  const [{ active: isDrawing }] = useDrawInterface()
+  const [wasDrawing, setWasDrawing] = useState(false)
+  const drawAnchorEl = useRef(null)
+  useEffect(
+    () => {
+      if (isDrawing) {
+        setWasDrawing(true)
+        handleClose()
+      }
+      if (!isDrawing && wasDrawing) {
+        handleOpen({
+          currentTarget: drawAnchorEl.current,
+        })
+      }
+    },
+    [isDrawing]
+  )
   return (
     <React.Fragment>
+      <div ref={drawAnchorEl} />
       <IndexCardItem
         title={title}
         subHeader={'Has not been run'}
@@ -43,11 +61,13 @@ const QueryCard = props => {
           <DeleteAction />
         </Actions>
       </IndexCardItem>
-
       <Popover
         open={open}
         anchorEl={anchorEl}
-        onClose={handleClose}
+        onClose={() => {
+          setWasDrawing(isDrawing)
+          handleClose()
+        }}
         anchorOrigin={{
           vertical: 'top',
           horizontal: 'left',


### PR DESCRIPTION
Persisted the isDrawing state when the QuerySelector closes and added a React effect to listen for when drawing completes so that the popup can be reopened with the updated GeometryJSON thus restoring the Draw button functionality.