### PR TITLE
Small fix for sources

### DIFF
--- a/src/main/webapp/sources.js
+++ b/src/main/webapp/sources.js
@@ -43,7 +43,7 @@ export const sources = gql`
 `
 
 export const Sources = props => {
-  const { sources } = props
+  const sources = props.sources === undefined ? [] : props.sources
   const offlineCount = sources.filter(source => !source.isAvailable).length
   const getIcon = source => (source.isAvailable ? OnlineIcon : OfflineIcon)
 


### PR DESCRIPTION
When a user was unauthenticated `props.sources` was undefined, which would cause the page to break. 