### PR TITLE
Add page based search

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ol": "^6.0.1",
     "on-finished": "^2.3.0",
     "polished": "^3.4.1",
+    "qs": "^6.9.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-loadable": "^5.5.0",

--- a/src/main/webapp/basic-search.js
+++ b/src/main/webapp/basic-search.js
@@ -148,8 +148,8 @@ export const populateDefaultQuery = (
   sorts = defaultSorts
 ) => ({
   srcs,
-  start: 1,
-  count: 250,
+  startIndex: 1,
+  pageSize: 250,
   filterTree,
   sorts,
   spellcheck: false,

--- a/src/main/webapp/intrigue-api/metacards/metacards.js
+++ b/src/main/webapp/intrigue-api/metacards/metacards.js
@@ -36,10 +36,10 @@ const typeDefs = `
     detail_level: String
 
     # Page size
-    count: Int
+    pageSize: Int
 
     # Start of paging. First element is 1, not 0.
-    start: Int
+    startIndex: Int
     type: String
   }
 

--- a/src/main/webapp/routes.js
+++ b/src/main/webapp/routes.js
@@ -40,6 +40,8 @@ import User from './user'
 import UserSettings from './user-settings'
 import loadable from 'react-loadable'
 
+import url from 'url'
+
 export const LoadingComponent = () => <LinearProgress />
 
 const Link = props => {
@@ -77,6 +79,21 @@ const loadDynamicRoute = route => {
     'simple-search': loadable({
       loader: () =>
         import(/* webpackChunkName: "simple-search" */ './simple-search'),
+      loading: LoadingComponent,
+    }),
+    search: loadable({
+      loader: () =>
+        import(/* webpackChunkName: "page-search" */ './search/search'),
+      loading: LoadingComponent,
+    }),
+    'search-results': loadable({
+      loader: () =>
+        import(/* webpackChunkName: "page-results" */ './search/results'),
+      loading: LoadingComponent,
+    }),
+    'search-details': loadable({
+      loader: () =>
+        import(/* webpackChunkName: "page-details" */ './search/details'),
       loading: LoadingComponent,
     }),
     'result-forms': loadable({
@@ -131,11 +148,12 @@ const routes = [
     loadDynamicRoute('workspaces')
   ),
   createRoute(
-    '/search',
-    'Search',
+    '/simple-search',
+    'Simple Search',
     SearchIcon,
     loadDynamicRoute('simple-search')
   ),
+  createRoute('/search', 'Search', SearchIcon, loadDynamicRoute('search')),
   createRoute('/sources', 'Sources', CloudIcon, loadDynamicRoute('sources')),
   createRoute(
     '/search-forms',
@@ -158,11 +176,22 @@ const otherRoutes = [
     path: '/workspaces/:id',
     component: loadDynamicRoute('workspace'),
   },
+  {
+    title: 'Results',
+    path: '/search/results',
+    component: loadDynamicRoute('search-results'),
+  },
+  {
+    title: 'Details',
+    path: '/search/results/:id',
+    component: loadDynamicRoute('search-details'),
+  },
 ]
 
 export const hasPath = path => {
   return routes.concat(otherRoutes).some(route => {
-    const match = matchPath(path, {
+    const { pathname } = url.parse(path)
+    const match = matchPath(pathname, {
       path: route.path,
       exact: true,
       strict: false,

--- a/src/main/webapp/search/details.js
+++ b/src/main/webapp/search/details.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import { getIn } from 'immutable'
+
+import { useQuery } from '@apollo/react-hooks'
+import gql from 'graphql-tag'
+
+import Paper from '@material-ui/core/Paper'
+import Container from '@material-ui/core/Container'
+import Grid from '@material-ui/core/Grid'
+import LinearProgress from '@material-ui/core/LinearProgress'
+import Typography from '@material-ui/core/Typography'
+
+import Thumbnail from '../thumbnail/thumbnail'
+
+const LoadingComponent = () => <LinearProgress />
+
+const searchByID = gql`
+  query SearchByID($ids: [ID]!) {
+    metacardsById(ids: $ids) {
+      attributes {
+        id
+        description
+        title
+        modified
+        thumbnail
+      }
+    }
+  }
+`
+
+const Details = () => {
+  const { id } = useParams()
+
+  const { loading, error, data } = useQuery(searchByID, {
+    variables: { ids: [id] },
+  })
+
+  if (loading) {
+    return <LoadingComponent />
+  }
+
+  if (error) {
+    return <Typography>Error getting details</Typography>
+  }
+
+  const attributes = getIn(
+    data,
+    ['metacardsById', 0, 'attributes', 0],
+    'missing'
+  )
+
+  if (attributes === 'missing') {
+    return <Typography>Details missing from response</Typography>
+  }
+
+  return (
+    <Container maxWidth="md" style={{ marginTop: 20 }}>
+      <Paper>
+        <Grid
+          container
+          direction="column"
+          justify="center"
+          alignItems="center"
+          spacing={2}
+        >
+          <Grid item xs={12}>
+            <Typography variant={'h4'} noWrap>
+              {attributes.title}
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Thumbnail src={attributes.thumbnail} />
+          </Grid>
+        </Grid>
+      </Paper>
+    </Container>
+  )
+}
+
+export default Details

--- a/src/main/webapp/search/results.js
+++ b/src/main/webapp/search/results.js
@@ -1,0 +1,218 @@
+import React from 'react'
+
+import gql from 'graphql-tag'
+import { useQuery } from '@apollo/react-hooks'
+
+import Grid from '@material-ui/core/Grid'
+import LinearProgress from '@material-ui/core/LinearProgress'
+import Typography from '@material-ui/core/Typography'
+import Tabs from '@material-ui/core/Tabs'
+import Tab from '@material-ui/core/Tab'
+import Table from '@material-ui/core/Table'
+import TableRow from '@material-ui/core/TableRow'
+import TableCell from '@material-ui/core/TableCell'
+import TableBody from '@material-ui/core/TableBody'
+import TablePagination from '@material-ui/core/TablePagination'
+import TextFieldsIcon from '@material-ui/icons/TextFields'
+import ImageIcon from '@material-ui/icons/Image'
+
+import useSearchRouting, { DetailsLink } from './search-routing'
+import Search from './search'
+import Thumbnail from '../thumbnail/thumbnail'
+
+const LoadingComponent = () => <LinearProgress />
+
+const metacardQuery = gql`
+  query TextQuery($filter: Json!, $settings: QuerySettingsInput) {
+    metacards(filterTree: $filter, settings: $settings) {
+      attributes {
+        id
+        description
+        title
+        modified
+        thumbnail
+      }
+      status {
+        hits
+        elapsed
+      }
+    }
+  }
+`
+
+const Paging = props => {
+  const { total, startIndex, pageSize, handleRoute } = props
+
+  const handleChangePage = (_, n) => {
+    const startIndex = n * pageSize + 1
+    handleRoute({ startIndex: startIndex })
+  }
+  const handleChangeRowsPerPage = e => {
+    const size = parseInt(e.target.value, 10)
+    handleRoute({ startIndex: 1, pageSize: size })
+  }
+
+  return (
+    <TablePagination
+      component="div"
+      rowsPerPageOptions={[15, 50, 100]}
+      colSpan={12}
+      count={total}
+      rowsPerPage={pageSize}
+      page={startIndex > pageSize ? (startIndex - 1) / pageSize : 0}
+      onChangePage={handleChangePage}
+      onChangeRowsPerPage={handleChangeRowsPerPage}
+    />
+  )
+}
+
+const GalleryThumbnail = ({ thumbnail }) => {
+  return thumbnail !== undefined ? <Thumbnail src={thumbnail} /> : null
+}
+
+const GalleryItem = props => {
+  const { result } = props
+
+  return (
+    <Grid item xs={3}>
+      <DetailsLink id={result.id}>
+        <GalleryThumbnail thumbnail={result.thumbnail} />
+        <Typography noWrap>{result.title}</Typography>
+      </DetailsLink>
+    </Grid>
+  )
+}
+
+const Gallery = ({ results }) => {
+  return (
+    <Grid container alignItems="flex-end">
+      {results.map(result => {
+        return <GalleryItem key={result.id} result={result} />
+      })}
+    </Grid>
+  )
+}
+
+const ResultTable = ({ results }) => {
+  return (
+    <Table>
+      <TableBody>
+        {results.map(result => {
+          return (
+            <TableRow key={result.id}>
+              <TableCell>
+                <DetailsLink id={result.id}>
+                  <Typography>{result.title}</Typography>
+                </DetailsLink>
+              </TableCell>
+            </TableRow>
+          )
+        })}
+      </TableBody>
+    </Table>
+  )
+}
+
+const QueryTypes = props => {
+  const { type, handleRoute } = props
+
+  const tabRoute = (_, type) => {
+    handleRoute({ type: type, startIndex: 1 })
+  }
+
+  return (
+    <Tabs value={type} onChange={tabRoute} centered>
+      <Tab
+        label="All"
+        icon={<TextFieldsIcon fontSize="small" />}
+        value="text"
+      />
+      <Tab label="Images" icon={<ImageIcon fontSize="small" />} value="image" />
+    </Tabs>
+  )
+}
+
+const ResultsView = props => {
+  const { isImageType } = props
+  return isImageType ? <Gallery {...props} /> : <ResultTable {...props} />
+}
+
+const getQueryFilter = props => {
+  const { query = '', isImageType = false } = props
+
+  const filter = {
+    type: 'AND',
+    filters: [{ type: 'ILIKE', property: 'anyText', value: query }],
+  }
+
+  if (isImageType) {
+    filter.filters.push({
+      type: '=',
+      property: 'media.type',
+      value: 'image/jpeg',
+    })
+  }
+
+  return filter
+}
+
+const Results = () => {
+  const { handleRoute, query, type, startIndex, pageSize } = useSearchRouting()
+
+  const isImageType = type === 'image'
+
+  const { loading, error, data } = useQuery(metacardQuery, {
+    variables: {
+      filter: getQueryFilter({ query, isImageType }),
+      settings: {
+        pageSize,
+        startIndex,
+      },
+    },
+  })
+
+  if (loading) {
+    return <LoadingComponent />
+  }
+
+  if (error) {
+    return <Typography>Error: Query Failed</Typography>
+  }
+
+  const { attributes, status } = data.metacards
+
+  const pagingProps = {
+    total: status.hits,
+    pageSize,
+    startIndex,
+    handleRoute,
+  }
+
+  return (
+    <Grid container justify="center" alignItems="center" spacing={2}>
+      <Grid item xs={12}>
+        <Search initialQuery={query} type={type} />
+      </Grid>
+      <Grid item xs={9}>
+        <QueryTypes type={type} handleRoute={handleRoute} />
+      </Grid>
+
+      <Grid item xs={9}>
+        <Typography color="textSecondary">
+          About {status.hits} results ({status.elapsed}
+          ms)
+        </Typography>
+      </Grid>
+
+      <Grid item xs={9}>
+        <ResultsView results={attributes} isImageType={isImageType} />
+      </Grid>
+
+      <Grid item xs={9}>
+        <Paging {...pagingProps} />
+      </Grid>
+    </Grid>
+  )
+}
+
+export default Results

--- a/src/main/webapp/search/search-routing.js
+++ b/src/main/webapp/search/search-routing.js
@@ -1,0 +1,53 @@
+import { Link, useLocation, useHistory } from 'react-router-dom'
+import qs from 'qs'
+import React from 'react'
+
+export const DetailsLink = props => {
+  const { id, children } = props
+  return (
+    <Link
+      to={{ pathname: `/search/results/${id}` }}
+      style={{ textDecoration: 'none' }}
+    >
+      {children}
+    </Link>
+  )
+}
+
+const defaultSettings = {
+  query: '',
+  type: 'text',
+  startIndex: 1,
+  pageSize: 15,
+}
+
+const useSearchRouting = () => {
+  const location = useLocation()
+  const history = useHistory()
+  const { search } = location
+  const params = qs.parse(search.substr(1))
+
+  const query = params['query'] || defaultSettings.query
+  const type = params['type'] || defaultSettings.type
+  const startIndex =
+    parseInt(params['startIndex'], 10) || defaultSettings.startIndex
+  const pageSize = parseInt(params['pageSize'], 10) || defaultSettings.pageSize
+
+  const settings = { query, type, startIndex, pageSize }
+
+  const handleRoute = props => {
+    const nextState = { ...settings, ...props }
+
+    history.push({
+      pathname: '/search/results',
+      search: `?${qs.stringify(nextState)}`,
+    })
+  }
+
+  return {
+    handleRoute,
+    ...settings,
+  }
+}
+
+export default useSearchRouting

--- a/src/main/webapp/search/search.js
+++ b/src/main/webapp/search/search.js
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react'
+
+import Grid from '@material-ui/core/Grid'
+import Button from '@material-ui/core/Button'
+import TextField from '@material-ui/core/TextField'
+
+import useSearchRouting from './search-routing'
+
+const Search = () => {
+  const { handleRoute, query: initialQuery = '' } = useSearchRouting()
+
+  const [query, setQuery] = useState(initialQuery)
+
+  useEffect(
+    () => {
+      setQuery(initialQuery)
+    },
+    [initialQuery]
+  )
+
+  const queryChange = e => {
+    setQuery(e.currentTarget.value)
+  }
+
+  const routeToResults = () => handleRoute({ query: query })
+
+  return (
+    <Grid
+      container
+      justify="center"
+      alignItems="center"
+      spacing={2}
+      style={{ height: 100 }}
+    >
+      <Grid item xs={3}>
+        <TextField
+          autoFocus
+          id={'query'}
+          variant={'outlined'}
+          value={query}
+          onChange={queryChange}
+          style={{ width: '100%' }}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              routeToResults({ query })
+            }
+          }}
+        />
+      </Grid>
+      <Grid item xs={1}>
+        <Button variant="outlined" onClick={() => routeToResults({ query })}>
+          Search
+        </Button>
+      </Grid>
+    </Grid>
+  )
+}
+
+export default Search

--- a/yarn.lock
+++ b/yarn.lock
@@ -11882,6 +11882,11 @@ qs@^6.6.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.8.0.tgz#87b763f0d37ca54200334cd57bb2ef8f68a1d081"
 
+qs@^6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
+  integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
+
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"


### PR DESCRIPTION
Adds an example of a URL driven set of pages that act as a hybrid application when combined with SSR.  Also fixes the paging parameters by replacing the CQL paging parameters with the JSON RPC paging parameters. 

http://localhost:8080/search/catalog/search
![image](https://user-images.githubusercontent.com/700518/73787823-44ca6e00-4759-11ea-9d1b-0eb3d0bba9b1.png)

http://localhost:8080/search/catalog/search/results?query=jpg&type=text&startIndex=1&pageSize=15
![image](https://user-images.githubusercontent.com/700518/73787893-56137a80-4759-11ea-8de2-63b854b26235.png)

http://localhost:8080/search/catalog/search/results?query=jpg&type=image&startIndex=1&pageSize=15
![image](https://user-images.githubusercontent.com/700518/73787937-6166a600-4759-11ea-85d1-bc62fe84e579.png)

http://localhost:8080/search/catalog/search/results/e0e485c32e8b47a0acd1773074b004d5
![image](https://user-images.githubusercontent.com/700518/73787970-73e0df80-4759-11ea-8a8d-072eec0fdc72.png)
