### PR TITLE
Removes network retries for unauthenticated users

### DIFF
--- a/src/main/webapp/retry/retry.js
+++ b/src/main/webapp/retry/retry.js
@@ -4,58 +4,72 @@ import SnackbarContent from '@material-ui/core/SnackbarContent'
 import Button from '@material-ui/core/Button'
 import CircularProgress from '@material-ui/core/CircularProgress'
 
+const ignorableStatusCodes = new Set(['UNAUTHENTICATED'])
+const hasIgnorable = err => {
+  if (!err) return false
+  if (err && err.graphQLErrors) {
+    return (
+      err.graphQLErrors.filter(error => ignorableStatusCodes.has(error.message))
+        .length > 0
+    )
+  }
+}
+
 export default props => {
   const {
     message,
     backgroundColor = '#e74c3c',
     color = 'white',
     onRetry = () => null,
+    error,
   } = props
 
   const [loading, setLoading] = useState(false)
 
   return (
-    <Snackbar
-      open={true}
-      anchorOrigin={{
-        vertical: 'bottom',
-        horizontal: 'right',
-      }}
-      message={message}
-    >
-      <SnackbarContent
-        style={{
-          backgroundColor,
-          color,
+    !hasIgnorable(error) && (
+      <Snackbar
+        open={true}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
         }}
-        action={
-          <Button
-            disabled={loading}
-            color="inherit"
-            size="small"
-            onClick={async () => {
-              setLoading(true)
-              try {
-                await onRetry()
-              } catch (err) {
-                //eslint-disable-next-line
-                console.log(err)
-              }
-              setLoading(false)
-            }}
-          >
-            Retry
-            {loading ? (
-              <CircularProgress
-                style={{ marginLeft: 10 }}
-                size={15}
-                color="inherit"
-              />
-            ) : null}
-          </Button>
-        }
-        message={<span id="client-snackbar">{message}</span>}
-      />
-    </Snackbar>
+        message={message}
+      >
+        <SnackbarContent
+          style={{
+            backgroundColor,
+            color,
+          }}
+          action={
+            <Button
+              disabled={loading}
+              color="inherit"
+              size="small"
+              onClick={async () => {
+                setLoading(true)
+                try {
+                  await onRetry()
+                } catch (err) {
+                  //eslint-disable-next-line
+                  console.log(err)
+                }
+                setLoading(false)
+              }}
+            >
+              Retry
+              {loading ? (
+                <CircularProgress
+                  style={{ marginLeft: 10 }}
+                  size={15}
+                  color="inherit"
+                />
+              ) : null}
+            </Button>
+          }
+          message={<span id="client-snackbar">{message}</span>}
+        />
+      </Snackbar>
+    )
   )
 }

--- a/src/main/webapp/retry/retry.js
+++ b/src/main/webapp/retry/retry.js
@@ -6,12 +6,12 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 
 const ignorableStatusCodes = new Set(['UNAUTHENTICATED'])
 const hasIgnorable = err => {
-  if (!err) return false
   if (err && err.graphQLErrors) {
     return (
       err.graphQLErrors.filter(error => ignorableStatusCodes.has(error.message))
         .length > 0
     )
+    return false
   }
 }
 

--- a/src/main/webapp/retry/retry.js
+++ b/src/main/webapp/retry/retry.js
@@ -11,7 +11,6 @@ const hasIgnorable = err => {
       err.graphQLErrors.filter(error => ignorableStatusCodes.has(error.message))
         .length > 0
     )
-    return false
   }
 }
 

--- a/src/main/webapp/workspaces/workspaces.js
+++ b/src/main/webapp/workspaces/workspaces.js
@@ -325,6 +325,7 @@ export default () => {
       <RetryNotification
         message={'Issue retrieving workspaces, would you like to retry?'}
         onRetry={refetch}
+        error={error}
       />
     )
   }


### PR DESCRIPTION
Network retries were previous popping up for workspace retrieval failures. This is unnecessary to retry when the user isn't logged in. Added a set to ignore certain graphQL errors, such as authentication. 