### PR TITLE
Fix Flickering of Index Cards

### DIFF
--- a/src/main/webapp/index-cards/index-cards.js
+++ b/src/main/webapp/index-cards/index-cards.js
@@ -113,8 +113,8 @@ export const IndexCardItem = props => {
             </Typography>
           )}
         </CardContent>
-        {children}
       </CardActionArea>
+      {children}
     </ItemContainer>
   )
 }


### PR DESCRIPTION
When action dialogs were a child of `CardActionArea`, that caused flickering on the index cards when clicking on said dialogs. 

I believe the reason `stopPropagation` does not work here is because the ripple effect is done with css

This effect can be seen in the gif posted in this PR: https://github.com/connexta/revelio/pull/207