### PR TITLE
Remove duplicate graphql query names

### DIFF
--- a/src/main/webapp/basic-search.js
+++ b/src/main/webapp/basic-search.js
@@ -497,7 +497,7 @@ const validate = (filterMap = Map()) => {
 }
 
 const MATCHTYPE_ATTRIBUTE = gql`
-  query getAttributeSuggestionListBasicSearch {
+  query getBasicSearchMatchType {
     systemProperties {
       basicSearchMatchType
     }

--- a/src/main/webapp/basic-search.js
+++ b/src/main/webapp/basic-search.js
@@ -497,7 +497,7 @@ const validate = (filterMap = Map()) => {
 }
 
 const MATCHTYPE_ATTRIBUTE = gql`
-  query getAttributeSuggestionList {
+  query getAttributeSuggestionListBasicSearch {
     systemProperties {
       basicSearchMatchType
     }

--- a/src/main/webapp/search/details.js
+++ b/src/main/webapp/search/details.js
@@ -14,7 +14,7 @@ import ErrorMessage from '../error'
 const LoadingComponent = () => <LinearProgress />
 
 const searchByID = gql`
-  query SearchByID($ids: [ID]!) {
+  query SearchByIdDetails($ids: [ID]!) {
     metacardsById(ids: $ids) {
       attributes {
         id

--- a/src/main/webapp/user-settings/result-form-select.js
+++ b/src/main/webapp/user-settings/result-form-select.js
@@ -10,7 +10,7 @@ import LinearProgress from '@material-ui/core/LinearProgress'
 import ErrorMessage from '../error'
 
 const resultForms = gql`
-  query SearchForms {
+  query SearchFormsAttributeGroup {
     metacardsByTag(tag: "attribute-group") {
       attributes {
         id


### PR DESCRIPTION
### What does this pr do?
- Fixes unique graphql query names

In order to prevent this in the future, you have to make sure the names given to graphql queries are unique. You can see the issue in VSCodes output tab, and the autocomplete for graphql inside of `gql` tags will stop working.

![image](https://user-images.githubusercontent.com/7236299/75167182-36c99680-56e2-11ea-9016-e8c58c7696f1.png)

![image](https://user-images.githubusercontent.com/7236299/75167238-4943d000-56e2-11ea-9bba-212892cf07f1.png)

This fix affects you if you have this plugin (which you should)
![image (20)](https://user-images.githubusercontent.com/7236299/75167305-624c8100-56e2-11ea-8d75-e21ced8bf4aa.png)

