### PR TITLE
Fix Sources Settings Regression

### DIFF
--- a/src/main/webapp/components/basic-search/basic-search-helper.js
+++ b/src/main/webapp/components/basic-search/basic-search-helper.js
@@ -37,10 +37,10 @@ const defaultSorts = [
 const defaultSources = ['ddf.distribution']
 export const populateDefaultQuery = (
   filterTree,
-  srcs = defaultSources,
+  sourceIds = defaultSources,
   sortPolicy = defaultSorts
 ) => ({
-  srcs,
+  sourceIds,
   startIndex: 1,
   pageSize: 250,
   filterTree,

--- a/src/main/webapp/components/basic-search/basic-search.js
+++ b/src/main/webapp/components/basic-search/basic-search.js
@@ -142,7 +142,6 @@ const BasicSources = ({ state = ['ddf.distribution'], setState }) => {
 
 const BasicSortOrder = props => {
   const { state, setState } = props
-
   return <SortOrder value={state} onChange={setState} />
 }
 
@@ -248,9 +247,9 @@ const getFilterMap = props => {
 }
 
 const createQuery = filterMap => {
-  const srcs = get(filterMap, 'sources')
+  const sourceIds = get(filterMap, 'sources')
   const sorts = get(filterMap, 'sortOrder')
-  return populateDefaultQuery(toFilterTree(filterMap), srcs, sorts)
+  return populateDefaultQuery(toFilterTree(filterMap), sourceIds, sorts)
 }
 
 export const BasicSearchQueryBuilder = props => {

--- a/src/main/webapp/components/query-builder/query-builder.tsx
+++ b/src/main/webapp/components/query-builder/query-builder.tsx
@@ -64,19 +64,19 @@ const QueryBuilder = (props: QueryBuilderProps) => {
   }
 
   const addSources = () => {
-    if (querySettings.sourceIds == undefined) {
+    if (querySettings.sources == undefined) {
       props.onChange({
         ...query,
-        sourceIds: [],
+        sources: [],
       })
     }
   }
 
   const addSorts = () => {
-    if (querySettings.sortPolicy == undefined) {
+    if (querySettings.sorts == undefined) {
       props.onChange({
         ...query,
-        sortPolicy: [],
+        sorts: [],
       })
     }
   }

--- a/src/main/webapp/components/query-builder/query-settings.tsx
+++ b/src/main/webapp/components/query-builder/query-settings.tsx
@@ -65,45 +65,45 @@ type QuerySettingsProps = {
 const QuerySettings = (props: QuerySettingsProps) => {
   const { settings = {} } = props
   if (
-    settings.sourceIds == undefined &&
-    settings.sortPolicy == undefined &&
+    settings.sources == undefined &&
+    settings.sorts == undefined &&
     settings.detail_level == undefined
   )
     return null
 
   return (
     <Section title="Search Settings">
-      {settings.sourceIds != undefined && (
+      {settings.sources != undefined && (
         <Box style={{ padding: '0px 16px' }}>
           <FilterCard
             label="Sources"
             onRemove={() => {
-              props.onChange({ ...settings, sourceIds: null })
+              props.onChange({ ...settings, sources: null })
             }}
           >
             <SourcesSelect
-              value={settings.sourceIds}
+              value={settings.sources}
               onChange={(value: any) => {
-                props.onChange({ ...settings, sourceIds: value })
+                props.onChange({ ...settings, sources: value })
               }}
             />
           </FilterCard>
         </Box>
       )}
-      {settings.sortPolicy != undefined && (
+      {settings.sorts != undefined && (
         <Box style={{ padding: '0px 16px' }}>
           <FilterCard
             label="Sorts"
             onRemove={() => {
-              props.onChange({ ...settings, sortPolicy: null })
+              props.onChange({ ...settings, sorts: null })
             }}
           >
             <SortOrder
-              value={getSorts(settings.sortPolicy)}
+              value={getSorts(settings.sorts)}
               onChange={(value: any) => {
                 props.onChange({
                   ...settings,
-                  sortPolicy: value.map(
+                  sorts: value.map(
                     (sort: any) => `${sort.propertyName},${sort.sortOrder}`
                   ),
                 })

--- a/src/main/webapp/components/query-builder/types.tsx
+++ b/src/main/webapp/components/query-builder/types.tsx
@@ -43,7 +43,7 @@ export type AttributeDefinition = {
     | 'DOUBLE'
 }
 export type QuerySettingsType = {
-  sourceIds?: string[] | null
-  sortPolicy?: string[] | null
+  sources?: string[] | null
+  sorts?: string[] | null
   detail_level?: string | null //Result Form title
 }

--- a/src/main/webapp/components/search-forms/editor.tsx
+++ b/src/main/webapp/components/search-forms/editor.tsx
@@ -74,11 +74,11 @@ type EditorProps = {
 }
 
 const queryToSearch = (query: QueryType) => {
-  const { sourceIds, sortPolicy, detail_level, filterTree } = query
+  const { sources, sorts, detail_level, filterTree } = query
   return {
     filterTree,
-    srcs: sourceIds || ['ddf.distribution'],
-    sortPolicy: (sortPolicy || []).map(sort => {
+    sourceIds: sources || ['ddf.distribution'],
+    sortPolicy: (sorts || []).map(sort => {
       //query builder might have sorts in the correct format already
       if (typeof sort !== 'string') {
         return sort

--- a/src/main/webapp/components/simple-search/simple-search.js
+++ b/src/main/webapp/components/simple-search/simple-search.js
@@ -74,12 +74,12 @@ const SimpleSearch = props => {
           />
           <QueryStatus
             sources={status}
-            onRun={srcs => {
+            onRun={sourceIds => {
               setPageIndex(0)
-              onSearch({ ...query, srcs })
+              onSearch({ ...query, sourceIds })
             }}
-            onCancel={srcs => {
-              srcs.forEach(src => {
+            onCancel={sourceIds => {
+              sourceIds.forEach(src => {
                 onCancel(src)
               })
             }}

--- a/src/main/webapp/components/sort-order/sort-order.js
+++ b/src/main/webapp/components/sort-order/sort-order.js
@@ -330,16 +330,24 @@ const Container = props => {
         Error Retrieving Attributes
       </ErrorMessage>
     )
-
+  const sortPolicy = getIn(
+    data,
+    ['user', 'preferences', 'querySettings', 'sortPolicy'],
+    undefined
+  )
+  let defaultValue = undefined
+  if (sortPolicy) {
+    defaultValue = sortPolicy.map(sort => {
+      const ret = { ...sort }
+      delete ret.__typename
+      return ret
+    })
+  }
   return (
     <SortOrder
       {...props}
       attributeDescriptors={getIn(data, ['metacardTypes'], [])}
-      defaultValue={getIn(
-        data,
-        ['user', 'preferences', 'querySettings', 'sortPolicy'],
-        undefined
-      )}
+      defaultValue={defaultValue}
     />
   )
 }

--- a/src/main/webapp/components/user-settings/search-settings.js
+++ b/src/main/webapp/components/user-settings/search-settings.js
@@ -29,7 +29,7 @@ const Defaults = props => (
       onChange={newValue => {
         const querySettings = merge(get(props.value, 'querySettings'), {
           federation: newValue !== null ? 'selected' : 'enterprise',
-          sourceIds: [newValue],
+          sourceIds: newValue,
         })
 
         props.onChange(set(props.value, 'querySettings', querySettings))

--- a/src/main/webapp/components/user-settings/source-select.js
+++ b/src/main/webapp/components/user-settings/source-select.js
@@ -63,7 +63,7 @@ const Sources = props => {
         value={props.value || [0]}
         onChange={e => {
           props.onChange(
-            e.target.value.includes(0) && props.value !== null
+            e.target.value.includes(0) && props.value != null
               ? null
               : e.target.value.filter(source => source !== 0)
           )
@@ -73,7 +73,7 @@ const Sources = props => {
         }
       >
         <MenuItem key={'allFields'} value={0}>
-          <Checkbox checked={props.value === null} />
+          <Checkbox checked={props.value == null} />
           <ListItemText primary={`All Sources`} />
         </MenuItem>
 

--- a/src/main/webapp/react-hooks/use-query-executor.js
+++ b/src/main/webapp/react-hooks/use-query-executor.js
@@ -118,15 +118,15 @@ const useQueryExecutor = () => {
 
   const onSearch = useCallback(
     async query => {
-      const { filterTree, srcs, ...settings } = query
+      const { filterTree, sourceIds, ...settings } = query
 
-      const status = srcs.reduce((status, src) => {
+      const status = sourceIds.reduce((status, src) => {
         return status.set(src, { type: 'source.pending' })
       }, Map())
 
       dispatch({ type: 'start', status })
 
-      srcs.map(async src => {
+      sourceIds.map(async src => {
         try {
           const { data } = await client.query({
             query: simpleSearch,


### PR DESCRIPTION
value was accidentally wrapped in an array which caused user preferences to break when selecting sources

also relaxes a couple checks



- Changes names of sources/sorts inside search forms  to mirror metacard schema
- Updates name of sources inside query executor to mirror json rpc schema
