### PR TITLE
Fix Thumbnail Story

### DIFF
--- a/src/main/webapp/components/thumbnail/thumbnail.stories.js
+++ b/src/main/webapp/components/thumbnail/thumbnail.stories.js
@@ -28,7 +28,7 @@ stories.add('Success', () => {
       Square: 'https://connexta.com/images/work1.jpg',
       Long: 'https://connexta.com/images/logo-ddf2.png',
     },
-    'Square'
+    'https://connexta.com/images/work1.jpg'
   )
   return (
     <div


### PR DESCRIPTION
The default value should be the value, not the key.

Was causing the `Success` thumbnail story to display an error symbol on load