### PR TITLE
Extract header section from query builder

### DIFF
--- a/src/main/webapp/components/basic-search/basic-search.js
+++ b/src/main/webapp/components/basic-search/basic-search.js
@@ -291,7 +291,7 @@ export const BasicSearchQueryBuilder = props => {
         {props.addOptionsRef ? (
           ReactDOM.createPortal(
             <AddButton addFilter={addFilter} />,
-            props.addOptionsRef.current
+            props.addOptionsRef
           )
         ) : (
           <AddButton addFilter={addFilter} />

--- a/src/main/webapp/components/basic-search/basic-search.js
+++ b/src/main/webapp/components/basic-search/basic-search.js
@@ -48,6 +48,7 @@ const timeAttributes = [
   'metacard.version.versioned-on',
   'modified',
 ]
+import ReactDOM from 'react-dom'
 
 const TextSearch = ({ text, handleChange }) => {
   return (
@@ -265,6 +266,14 @@ export const BasicSearchQueryBuilder = props => {
 
   const text = filterMap.get('text')
 
+  const addFilter = filter => {
+    onChange(
+      filterMap.merge({
+        [filter]: defaultFilters[filter],
+      })
+    )
+  }
+
   return (
     <React.Fragment>
       <Paper
@@ -279,15 +288,14 @@ export const BasicSearchQueryBuilder = props => {
           text={text}
           handleChange={e => onChange(filterMap.set(TEXT_KEY, e.target.value))}
         />
-        <AddButton
-          addFilter={filter => {
-            onChange(
-              filterMap.merge({
-                [filter]: defaultFilters[filter],
-              })
-            )
-          }}
-        />
+        {props.addOptionsRef ? (
+          ReactDOM.createPortal(
+            <AddButton addFilter={addFilter} />,
+            props.addOptionsRef.current
+          )
+        ) : (
+          <AddButton addFilter={addFilter} />
+        )}
       </Paper>
 
       {remove(filterMap, 'text')

--- a/src/main/webapp/components/query-builder/query-builder.tsx
+++ b/src/main/webapp/components/query-builder/query-builder.tsx
@@ -1,28 +1,29 @@
-import * as React from 'react'
+import Box from '@material-ui/core/Box'
 import Button from '@material-ui/core/Button'
-import Divider from '@material-ui/core/Divider'
 import Menu from '@material-ui/core/Menu'
 import MenuItem from '@material-ui/core/MenuItem'
-import Box from '@material-ui/core/Box'
-import TextField from '@material-ui/core/TextField'
 import { getIn, setIn } from 'immutable'
+import * as React from 'react'
 import useAnchorEl from '../../react-hooks/use-anchor-el'
 import { defaultFilter } from './filter/filter-utils'
 import Filter from './filter/individual-filter'
 import QuerySettings from './query-settings'
 import { AttributeDefinition, QueryFilter, QueryType } from './types'
 
+const ReactDOM = require('react-dom')
+
 export type QueryBuilderProps = {
   attributeDefinitions?: AttributeDefinition[]
   onChange: (query: QueryType) => void
   query?: QueryType
+  addOptionsRef: React.MutableRefObject<HTMLDivElement>
 }
 
 const AddButton = (props: { options: any }) => {
   const [anchorEl, open, close] = useAnchorEl()
   return (
     <React.Fragment>
-      <Button variant="outlined" style={{ marginLeft: 10 }} onClick={open}>
+      <Button variant="outlined" onClick={open}>
         Add Option
       </Button>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={close}>
@@ -98,20 +99,10 @@ const QueryBuilder = (props: QueryBuilderProps) => {
       display="flex"
       flexDirection="column"
     >
-      <Box display="flex" style={{ padding: 8 }} alignItems="center">
-        <TextField
-          fullWidth
-          value={query.title}
-          variant="outlined"
-          label="Search Title"
-          onChange={event => {
-            props.onChange(setIn(query, ['title'], event.target.value))
-          }}
-          autoFocus
-        />
-        <AddButton options={options} />
-      </Box>
-      <Divider />
+      {ReactDOM.createPortal(
+        <AddButton options={options} />,
+        props.addOptionsRef.current
+      )}
       {filters.map((filter: QueryFilter, i: number) => (
         <Box key={i} style={{ padding: '0px 16px' }}>
           <Filter

--- a/src/main/webapp/components/query-builder/query-builder.tsx
+++ b/src/main/webapp/components/query-builder/query-builder.tsx
@@ -16,7 +16,7 @@ export type QueryBuilderProps = {
   attributeDefinitions?: AttributeDefinition[]
   onChange: (query: QueryType) => void
   query?: QueryType
-  addOptionsRef: React.MutableRefObject<HTMLDivElement>
+  addOptionsRef: HTMLDivElement
 }
 
 const AddButton = (props: { options: any }) => {
@@ -99,10 +99,11 @@ const QueryBuilder = (props: QueryBuilderProps) => {
       display="flex"
       flexDirection="column"
     >
-      {ReactDOM.createPortal(
-        <AddButton options={options} />,
-        props.addOptionsRef.current
-      )}
+      {props.addOptionsRef &&
+        ReactDOM.createPortal(
+          <AddButton options={options} />,
+          props.addOptionsRef
+        )}
       {filters.map((filter: QueryFilter, i: number) => (
         <Box key={i} style={{ padding: '0px 16px' }}>
           <Filter

--- a/src/main/webapp/components/query-editor/query-editor.tsx
+++ b/src/main/webapp/components/query-editor/query-editor.tsx
@@ -10,17 +10,25 @@ import React from 'react'
 import useAnchorEl from '../../react-hooks/use-anchor-el'
 import { AttributeDefinition, QueryType } from '../query-builder/types'
 
-const Header = (props: any) => {
-  const [anchorEl, handleOpen, handleClose, open] = useAnchorEl(props)
+type HeaderProps = {
+  queryInteractions?: React.FunctionComponent<{}>
+  query?: QueryType
+  addOptionsRef?: (el: HTMLDivElement) => void
+  onChange: (query: QueryType) => void
+}
+
+const Header = (props: HeaderProps) => {
+  const { query = {} } = props
+  const [anchorEl, handleOpen, handleClose, open] = useAnchorEl()
   return (
     <Box display="flex" style={{ padding: 8 }} alignItems="center">
       <TextField
         fullWidth
-        value={props.query.title}
+        value={query.title}
         variant="outlined"
         label="Search Title"
         onChange={event => {
-          props.onChange(set(props.query, 'title', event.target.value))
+          props.onChange(set(query, 'title', event.target.value))
         }}
         autoFocus
       />
@@ -40,6 +48,7 @@ const Header = (props: any) => {
     </Box>
   )
 }
+
 type FooterProps = {
   onSearch: () => void
   onSave?: () => void
@@ -82,7 +91,7 @@ type EditorProps = {
   queryBuilder: React.FunctionComponent<{
     query?: QueryType
     onChange: (query: QueryType) => void
-    addOptionsRef?: React.MutableRefObject<HTMLDivElement>
+    addOptionsRef?: HTMLDivElement
   }>
   onChange: (query: QueryType) => void
 }
@@ -113,7 +122,7 @@ export default (props: EditorProps) => {
   const onSearch = () => {
     props.onSearch(queryToSearch(query))
   }
-  const addOptionsRef = React.useRef(document.createElement('div'))
+  const [addOptionsRef, setAddOptionsRef] = React.useState()
 
   return (
     <Box width="100%" display="flex" flexDirection="column" height="100%">
@@ -126,7 +135,7 @@ export default (props: EditorProps) => {
         <Header
           query={query}
           queryInteractions={props.queryInteractions}
-          addOptionsRef={addOptionsRef}
+          addOptionsRef={el => setAddOptionsRef(el)}
           onChange={props.onChange}
         />
       </Box>

--- a/src/main/webapp/components/query-editor/query-editor.tsx
+++ b/src/main/webapp/components/query-editor/query-editor.tsx
@@ -1,8 +1,45 @@
 import Box from '@material-ui/core/Box'
 import Button from '@material-ui/core/Button'
+import Divider from '@material-ui/core/Divider'
+import IconButton from '@material-ui/core/IconButton'
+import Menu from '@material-ui/core/Menu'
+import TextField from '@material-ui/core/TextField'
+import MoreVertIcon from '@material-ui/icons/MoreVert'
+import { set } from 'immutable'
 import React from 'react'
+import useAnchorEl from '../../react-hooks/use-anchor-el'
 import { AttributeDefinition, QueryType } from '../query-builder/types'
 
+const Header = (props: any) => {
+  const [anchorEl, handleOpen, handleClose, open] = useAnchorEl(props)
+  return (
+    <Box display="flex" style={{ padding: 8 }} alignItems="center">
+      <TextField
+        fullWidth
+        value={props.query.title}
+        variant="outlined"
+        label="Search Title"
+        onChange={event => {
+          props.onChange(set(props.query, 'title', event.target.value))
+        }}
+        autoFocus
+      />
+      <div style={{ marginLeft: 10 }} ref={props.addOptionsRef} />
+      <IconButton
+        style={{
+          marginLeft: 10,
+        }}
+        onClick={handleOpen}
+      >
+        <MoreVertIcon />
+      </IconButton>
+
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        {props.queryInteractions}
+      </Menu>
+    </Box>
+  )
+}
 type FooterProps = {
   onSearch: () => void
   onSave?: () => void
@@ -38,12 +75,14 @@ const Footer = (props: FooterProps) => {
 
 type EditorProps = {
   attributeDefinitions?: AttributeDefinition[]
+  queryInteractions?: React.FunctionComponent<{}>
   query?: QueryType
   onSave: (query: QueryType) => void
   onSearch: (query: any) => void
   queryBuilder: React.FunctionComponent<{
     query?: QueryType
     onChange: (query: QueryType) => void
+    addOptionsRef?: React.MutableRefObject<HTMLDivElement>
   }>
   onChange: (query: QueryType) => void
 }
@@ -74,10 +113,30 @@ export default (props: EditorProps) => {
   const onSearch = () => {
     props.onSearch(queryToSearch(query))
   }
+  const addOptionsRef = React.useRef(document.createElement('div'))
 
   return (
     <Box width="100%" display="flex" flexDirection="column" height="100%">
-      <QueryBuilder query={query} onChange={props.onChange} />
+      <Box
+        width="100%"
+        style={{
+          marginTop: '10px',
+        }}
+      >
+        <Header
+          query={query}
+          queryInteractions={props.queryInteractions}
+          addOptionsRef={addOptionsRef}
+          onChange={props.onChange}
+        />
+      </Box>
+
+      <Divider />
+      <QueryBuilder
+        query={query}
+        onChange={props.onChange}
+        addOptionsRef={addOptionsRef}
+      />
       <Box
         width="100%"
         style={{

--- a/src/main/webapp/react-hooks/use-anchor-el.tsx
+++ b/src/main/webapp/react-hooks/use-anchor-el.tsx
@@ -1,15 +1,24 @@
 import { useState } from 'react'
 
+type UseAnchorElProps = {
+  onClose?: () => void
+}
+
 //Used as shorthand for anchorEl logic on Material UI Menus/Popovers
-const useAnchorEl = () => {
+const useAnchorEl = (props: UseAnchorElProps = {}) => {
   const [anchorEl, setAnchorEl] = useState(null)
   const open: any = (event: any) => {
     setAnchorEl(event.currentTarget)
   }
   const close = () => {
     setAnchorEl(null)
+    if (props.onClose) {
+      props.onClose()
+    }
   }
-  return [anchorEl, open, close]
+
+  const isOpen = Boolean(anchorEl)
+  return [anchorEl, open, close, isOpen]
 }
 
 export default useAnchorEl


### PR DESCRIPTION
This pr lets us add a three dot menu in the top section of the query editor, which will be used in switching between different search forms.

![image](https://user-images.githubusercontent.com/4467636/75829918-b0a9f180-5d6c-11ea-8a6a-52992e85d78c.png)

