### PR TITLE
Automatically generate schema using http request

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "start": "cross-env NODE_OPTIONS=\"--inspect --max_old_space_size=8192\" ace start --middleware src/main/graphql-server/middleware.js",
     "start:prod": "cross-env NODE_ENV=production node target/server/bundle.middleware.js",
     "fmt": "ace format -w",
+    "graphql:schema": "node ./scripts/generate-schema-json > schema.json && yarn fmt",
     "start:test": "ace start --env=test",
     "test:api": "mocha src/main/webapp/intrigue-api/test",
     "pretest": "ace format && eslint src",

--- a/scripts/generate-schema-json.js
+++ b/scripts/generate-schema-json.js
@@ -1,0 +1,23 @@
+const fetch = require('node-fetch')
+
+const body = JSON.stringify({
+  operationName: 'IntrospectionQuery',
+  variables: {},
+  query:
+    'query IntrospectionQuery {\n  __schema {\n    queryType {\n      name\n    }\n    mutationType {\n      name\n    }\n    subscriptionType {\n      name\n    }\n    types {\n      ...FullType\n    }\n    directives {\n      name\n      description\n      locations\n      args {\n        ...InputValue\n      }\n    }\n  }\n}\n\nfragment FullType on __Type {\n  kind\n  name\n  description\n  fields(includeDeprecated: true) {\n    name\n    description\n    args {\n      ...InputValue\n    }\n    type {\n      ...TypeRef\n    }\n    isDeprecated\n    deprecationReason\n  }\n  inputFields {\n    ...InputValue\n  }\n  interfaces {\n    ...TypeRef\n  }\n  enumValues(includeDeprecated: true) {\n    name\n    description\n    isDeprecated\n    deprecationReason\n  }\n  possibleTypes {\n    ...TypeRef\n  }\n}\n\nfragment InputValue on __InputValue {\n  name\n  description\n  type {\n    ...TypeRef\n  }\n  defaultValue\n}\n\nfragment TypeRef on __Type {\n  kind\n  name\n  ofType {\n    kind\n    name\n    ofType {\n      kind\n      name\n      ofType {\n        kind\n        name\n        ofType {\n          kind\n          name\n          ofType {\n            kind\n            name\n            ofType {\n              kind\n              name\n              ofType {\n                kind\n                name\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n}\n',
+})
+
+const runIntrospectionQuery = () => {
+  fetch('http://localhost:8080/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body,
+  })
+    .then(res => res.json())
+    .then(json => console.log(JSON.stringify(json, null, 2)))
+    .catch(err => console.log('Error: ', err))
+}
+
+runIntrospectionQuery()

--- a/scripts/generate-schema-json.js
+++ b/scripts/generate-schema-json.js
@@ -17,7 +17,6 @@ const runIntrospectionQuery = () => {
   })
     .then(res => res.json())
     .then(json => console.log(JSON.stringify(json, null, 2)))
-    .catch(err => console.log('Error: ', err))
 }
 
 runIntrospectionQuery()


### PR DESCRIPTION
- Run `yarn graphql:schema` with dev server running and `schema.json` will automatically be updated.