### PR TITLE
Normalize queries on workspaces

### DIFF
--- a/src/main/webapp/components/query-editor/query-editor.tsx
+++ b/src/main/webapp/components/query-editor/query-editor.tsx
@@ -97,7 +97,7 @@ export type EditorProps = {
   attributeDefinitions?: AttributeDefinition[]
   queryInteractions?: QueryInteraction[]
   query?: QueryType
-  onSearch: (query: QueryType) => void
+  onSearch: () => void
   queryBuilder: React.FunctionComponent<{
     query?: QueryType
     onChange: (query: QueryType) => void
@@ -106,32 +106,9 @@ export type EditorProps = {
   onChange: (query: QueryType) => void
 }
 
-const queryToSearch = (query: QueryType) => {
-  const { sources, sorts, detail_level, filterTree } = query
-  return {
-    filterTree,
-    sourceIds: sources || ['ddf.distribution'],
-    sortPolicy: (sorts || []).map(sort => {
-      //query builder might have sorts in the correct format already
-      if (typeof sort !== 'string') {
-        return sort
-      }
-      const splitIndex = sort.lastIndexOf(',')
-      return {
-        propertyName: sort.substring(0, splitIndex),
-        sortOrder: sort.substring(splitIndex + 1, sort.length),
-      }
-    }),
-    detail_level: detail_level === 'All Fields' ? undefined : detail_level,
-  }
-}
-
 export default (props: EditorProps) => {
   const query = props.query || {}
   const QueryBuilder = props.queryBuilder
-  const onSearch = () => {
-    props.onSearch(queryToSearch(query))
-  }
   const [addOptionsRef, setAddOptionsRef] = React.useState<HTMLDivElement>()
 
   return (
@@ -162,7 +139,7 @@ export default (props: EditorProps) => {
           marginTop: '10px',
         }}
       >
-        <Footer onSearch={onSearch} />
+        <Footer onSearch={props.onSearch} />
       </Box>
     </Box>
   )

--- a/src/main/webapp/components/query-manager/add-query.tsx
+++ b/src/main/webapp/components/query-manager/add-query.tsx
@@ -11,7 +11,7 @@ export default (props: AddQueryProps) => {
   const [query, setQuery] = React.useState<{ id?: string }>({
     id: new Date().toString(),
   })
-  const { onSearch, QueryEditor } = props
+  const { onSearch, QueryEditor, queries, onChange } = props
 
   const navBarLeftRef = React.useContext(NavigationBarContext)
   const [anchorEl, setAnchorEl] = React.useState<any>(null)
@@ -23,6 +23,7 @@ export default (props: AddQueryProps) => {
     setAnchorEl(null)
   }
 
+  const hasQueries = queries && queries.length > 0
   const CreateSearch = () =>
     navBarLeftRef
       ? ReactDOM.createPortal(
@@ -37,7 +38,7 @@ export default (props: AddQueryProps) => {
     <React.Fragment>
       <CreateSearch />
 
-      {!props.hasQueries && (
+      {!hasQueries && (
         <div style={{ textAlign: 'center', marginTop: '10px' }}>
           <Typography color="textSecondary">
             New searches will appear here
@@ -52,8 +53,9 @@ export default (props: AddQueryProps) => {
       <QueryEditorPopover
         query={query}
         QueryEditor={QueryEditor}
-        onSearch={query => {
-          onSearch(query)
+        onSearch={() => {
+          onChange(query)
+          onSearch(query.id!)
           handleClose()
           setQuery({ id: new Date().toString() })
         }}

--- a/src/main/webapp/components/query-manager/query-editor-popover.tsx
+++ b/src/main/webapp/components/query-manager/query-editor-popover.tsx
@@ -86,7 +86,7 @@ export default (props: QueryEditorPopoverProps) => {
             AdvancedSearchQueryBuilder
           )}
           queryInteractions={queryInteractions}
-          onSearch={q => onSearch({ ...getBaseQueryFields(query), ...q })}
+          onSearch={onSearch}
           onChange={q => onChange({ ...getBaseQueryFields(query), ...q })}
         />
       </Box>

--- a/src/main/webapp/components/query-manager/query-manager.stories.tsx
+++ b/src/main/webapp/components/query-manager/query-manager.stories.tsx
@@ -12,7 +12,7 @@ import { button } from '@storybook/addon-knobs'
 
 stories.add('Basic', () => {
   const [queries, setQueries] = useState(sampleQueries)
-  const [query, setQuery] = useState(sampleQueries[0].id)
+  const [query, setQuery] = React.useState(sampleQueries[0].id)
   const [
     navBarLeftRef,
     setNavBarLeftRef,
@@ -33,10 +33,12 @@ stories.add('Basic', () => {
         queries={queries}
         currentQuery={query}
         QueryEditor={QueryEditor}
-        onChange={queries => setQueries(queries)}
-        onSearch={query => {
-          action('onSearch')(query)
-          setQuery(query.id)
+        onChange={queries => {
+          setQueries(queries)
+        }}
+        onSearch={id => {
+          action('onSearch')(id)
+          setQuery(id)
         }}
       />
     </NavigationBarContext.Provider>

--- a/src/main/webapp/components/query-manager/query-manager.tsx
+++ b/src/main/webapp/components/query-manager/query-manager.tsx
@@ -44,7 +44,7 @@ const QueryCard = (props: QueryCardProps) => {
       <IndexCardItem
         title={query.title}
         subHeader={'Has not been run'}
-        onClick={() => onSearch(query)}
+        onClick={onSearch}
       >
         <Actions>
           <EditAction onEdit={handleOpen} />
@@ -64,12 +64,17 @@ const QueryCard = (props: QueryCardProps) => {
 }
 
 const QuerySelector = (props: QuerySelectorProps) => {
-  const { queries, currentQuery } = props
+  const { queries, currentQuery, onSearch } = props
   const hasQueries = queries && queries.length > 0
   const [anchorEl, handleOpen, handleClose, open] = useAnchorEl()
 
   const queryCards = queries.map(query => (
-    <QueryCard {...props} query={query} key={query.id} />
+    <QueryCard
+      {...props}
+      query={query}
+      key={query.id}
+      onSearch={() => onSearch(query.id!)}
+    />
   ))
 
   return hasQueries ? (
@@ -77,6 +82,7 @@ const QuerySelector = (props: QuerySelectorProps) => {
       <QueryCard
         {...props}
         query={queries.find(query => query.id === currentQuery)}
+        onSearch={() => onSearch(currentQuery)}
       />
       <Button
         color="primary"
@@ -107,7 +113,7 @@ const QuerySelector = (props: QuerySelectorProps) => {
 }
 
 const QueryManager = (props: QueryManagerProps) => {
-  const { queries, QueryEditor, onSearch } = props
+  const { queries } = props
 
   const onChange = (query: QueryType) => {
     const index = queries.findIndex(q => q.id === query.id)
@@ -115,18 +121,10 @@ const QueryManager = (props: QueryManagerProps) => {
       index !== -1 ? set(queries, index, query) : merge([query], queries)
     props.onChange(updatedQueries)
   }
-  const hasQueries = queries && queries.length > 0
 
   return (
     <React.Fragment>
-      <AddQuery
-        onSearch={query => {
-          onChange(query)
-          onSearch(query)
-        }}
-        QueryEditor={QueryEditor}
-        hasQueries={hasQueries}
-      />
+      <AddQuery {...props} onChange={onChange} />
       <QuerySelector {...props} onChange={onChange} />
     </React.Fragment>
   )

--- a/src/main/webapp/components/query-manager/types.tsx
+++ b/src/main/webapp/components/query-manager/types.tsx
@@ -7,13 +7,19 @@ type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
 export type QueryCardProps = {
   QueryEditor: React.FunctionComponent<EditorProps>
   query?: QueryType
-  onSearch: (query: QueryType) => void
+  onSearch: () => void
   onChange: (query: QueryType) => void
 }
-export type QuerySelectorProps = QueryCardProps & {
+export type QuerySelectorProps = Overwrite<
+  QueryCardProps,
+  { onSearch: (id: string) => void }
+> & {
   queries: QueryType[]
   currentQuery: string
 }
+
+export type AddQueryProps = QuerySelectorProps
+
 export type QueryEditorPopoverProps = QueryCardProps & {
   anchorEl: HTMLDivElement
   onClose: () => void
@@ -23,9 +29,3 @@ export type QueryManagerProps = Overwrite<
   QuerySelectorProps,
   { onChange: (queries: QueryType[]) => void }
 >
-
-export type AddQueryProps = {
-  QueryEditor: React.FunctionComponent<EditorProps>
-  onSearch: (query: QueryType) => void
-  hasQueries: boolean
-}


### PR DESCRIPTION
This pr makes workspace queries always have the same form, instead of being possibly transformed into a executable query. Doing this will aid in not having to transform these queries when doing create or save mutations. 