### PR TITLE
Add Default Search Form To Default Preferences

### DIFF
--- a/src/main/webapp/intrigue-api/user/user.js
+++ b/src/main/webapp/intrigue-api/user/user.js
@@ -124,6 +124,9 @@ const getDefaultPreferences = async fetch => {
           sortOrder: 'descending',
         },
       ],
+      template: {
+        id: null,
+      },
     },
   }
 }


### PR DESCRIPTION
This was causing issues when user preferences were uninitialized because the typename for `template` isn't defined on load