### PR TITLE
Change metacard interactions to use permissions hook

### DIFF
--- a/src/main/webapp/components/confirm-delete/confirm-delete.js
+++ b/src/main/webapp/components/confirm-delete/confirm-delete.js
@@ -42,7 +42,8 @@ const ConfirmDeleteAction = props => {
 
 const ConfirmDeleteMetacardInteraction = props => {
   const { setDialogProps } = useContext(MetacardInteractionsDialogContext)
-  if (!props.isWritable) {
+  const { permissions } = props
+  if (!permissions.canWrite) {
     return null
   }
   const { itemName } = props

--- a/src/main/webapp/components/index-cards/index-cards.js
+++ b/src/main/webapp/components/index-cards/index-cards.js
@@ -53,13 +53,15 @@ export { ShareAction, DeleteAction }
 export const Actions = props => {
   const getPermissions = usePermissions(props)
 
-  if (!props.attributes || !getPermissions) {
+  if (!getPermissions) {
     return null
   }
   const actions = React.Children.map(props.children, child => {
-    return React.cloneElement(child, {
-      permissions: getPermissions(props.attributes),
-    })
+    return React.isValidElement(child)
+      ? React.cloneElement(child, {
+          permissions: getPermissions(props.attributes),
+        })
+      : null
   })
 
   return <CardActions>{actions}</CardActions>

--- a/src/main/webapp/components/index-cards/index-cards.js
+++ b/src/main/webapp/components/index-cards/index-cards.js
@@ -53,7 +53,7 @@ export { ShareAction, DeleteAction }
 export const Actions = props => {
   const getPermissions = usePermissions(props)
 
-  if (!props.attributes) {
+  if (!props.attributes || !getPermissions) {
     return null
   }
   const actions = React.Children.map(props.children, child => {

--- a/src/main/webapp/components/index-cards/index-cards.stories.js
+++ b/src/main/webapp/components/index-cards/index-cards.stories.js
@@ -35,6 +35,11 @@ const generateItems = n => {
   return items
 }
 
+const securityAttributes = {
+  security_access_individuals_read: [''],
+  security_access_administrators: [''],
+}
+
 stories.add('basic usage', () => {
   const n = number('Number of Items', 10)
   const items = generateItems(n)
@@ -45,9 +50,9 @@ stories.add('basic usage', () => {
       {items.map(item => {
         return (
           <IndexCardItem starred key={item.id} {...item}>
-            <Actions>
-              <ShareAction isAdmin={true} onShare={action('onShare')} />
-              <DeleteAction isWritable={true} onDelete={action('onDelete')} />
+            <Actions attributes={securityAttributes}>
+              <ShareAction onShare={action('onShare')} />
+              <DeleteAction onDelete={action('onDelete')} />
               <DuplicateAction onDuplicate={action('onDuplicate')} />
             </Actions>
           </IndexCardItem>

--- a/src/main/webapp/components/metacard-interaction/metacard-interactions-dropdown.tsx
+++ b/src/main/webapp/components/metacard-interaction/metacard-interactions-dropdown.tsx
@@ -1,11 +1,12 @@
-import React, { createContext, useState, Fragment } from 'react'
-import IconButton from '@material-ui/core/IconButton'
-import MoreVertIcon from '@material-ui/icons/MoreVert'
-import Menu from '@material-ui/core/Menu'
-import useAnchorEl from '../../react-hooks/use-anchor-el'
-import MenuItem from '@material-ui/core/MenuItem'
 import Box from '@material-ui/core/Box'
 import Dialog, { DialogProps } from '@material-ui/core/Dialog'
+import IconButton from '@material-ui/core/IconButton'
+import Menu from '@material-ui/core/Menu'
+import MenuItem from '@material-ui/core/MenuItem'
+import MoreVertIcon from '@material-ui/icons/MoreVert'
+import React, { createContext, Fragment, useState } from 'react'
+import useAnchorEl from '../../react-hooks/use-anchor-el'
+import { Permissions } from '../../react-hooks/use-get-permissions'
 
 const MetacardInteractionsDialogContext = createContext<any>({
   setProps: () => {
@@ -22,7 +23,7 @@ type MetacardInteractionsDropdownProps = {
 }
 
 const MetacardInteractionsDropdown = (
-  props: MetacardInteractionsDropdownProps
+  props: MetacardInteractionsDropdownProps & { permissions?: Permissions }
 ) => {
   const [anchorEl, open, close, isOpen] = useAnchorEl()
 
@@ -48,7 +49,11 @@ const MetacardInteractionsDropdown = (
                 style={{ padding: 0 }}
                 onClick={() => close()}
               >
-                {child}
+                {React.isValidElement(child)
+                  ? React.cloneElement(child, {
+                      permissions: props.permissions,
+                    })
+                  : null}
               </MenuItem>
             )
           })}

--- a/src/main/webapp/components/query-manager/query-manager.tsx
+++ b/src/main/webapp/components/query-manager/query-manager.tsx
@@ -2,7 +2,7 @@ import Button from '@material-ui/core/Button'
 import Popover from '@material-ui/core/Popover'
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import { merge, set } from 'immutable'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState, useContext } from 'react'
 import useAnchorEl from '../../react-hooks/use-anchor-el'
 import {
   Actions,
@@ -11,6 +11,7 @@ import {
   IndexCardItem,
 } from '../index-cards'
 import { QueryType } from '../query-builder/types'
+import { WorkspaceContext } from '../workspace/workspace-context'
 import AddQuery from './add-query'
 import QueryEditorPopover from './query-editor-popover'
 import { QueryCardProps, QueryManagerProps, QuerySelectorProps } from './types'
@@ -22,6 +23,7 @@ const QueryCard = (props: QueryCardProps) => {
   const [{ active: isDrawing }] = useDrawInterface()
   const [wasDrawing, setWasDrawing] = useState(false)
   const drawAnchorEl = useRef(null)
+  const attributes = useContext(WorkspaceContext)
 
   useEffect(
     () => {
@@ -46,7 +48,7 @@ const QueryCard = (props: QueryCardProps) => {
         subHeader={'Has not been run'}
         onClick={onSearch}
       >
-        <Actions>
+        <Actions attributes={attributes}>
           <EditAction onEdit={handleOpen} />
           <DeleteAction />
         </Actions>

--- a/src/main/webapp/components/result-forms/route.js
+++ b/src/main/webapp/components/result-forms/route.js
@@ -1,36 +1,26 @@
-import React, { Fragment, useState } from 'react'
-
-import gql from 'graphql-tag'
-import { useQuery, useMutation } from '@apollo/react-hooks'
-
-import ResultForms from './result-forms'
-
+import { useMutation, useQuery } from '@apollo/react-hooks'
 import Dialog from '@material-ui/core/Dialog'
-
 import LinearProgress from '@material-ui/core/LinearProgress'
-import { Notification } from '../notification/notification'
+import gql from 'graphql-tag'
+import React, { Fragment, useState } from 'react'
 import {
-  getSecurityAttributesFromMetacard,
-  getPermissions,
-} from '../sharing/sharing-utils'
-
-import {
-  IndexCards,
-  IndexCardItem,
+  Actions,
   AddCardItem,
   DeleteAction,
-  ShareAction,
-  Actions,
+  IndexCardItem,
+  IndexCards,
   ReadOnly,
+  ShareAction,
 } from '../index-cards'
-import RetryComponent from '../network-retry/snackbar-retry'
-
 import {
-  MetacardInteractionsDropdown,
-  ShareMetacardInteraction,
   ConfirmDeleteMetacardInteraction,
   EditMetacardInteraction,
+  MetacardInteractionsDropdown,
+  ShareMetacardInteraction,
 } from '../index-cards/metacard-interactions'
+import RetryComponent from '../network-retry/snackbar-retry'
+import { Notification } from '../notification/notification'
+import ResultForms from './result-forms'
 
 const Loading = () => {
   return <LinearProgress />
@@ -63,15 +53,7 @@ const AddItem = props => {
 }
 
 const Item = props => {
-  const { form, Editor, onDelete, user } = props
-
-  const securityAttributes = getSecurityAttributesFromMetacard(form)
-  const { canShare, canWrite } = getPermissions(
-    user.email,
-    user.roles,
-    securityAttributes,
-    form.owner
-  )
+  const { form, Editor, onDelete } = props
   const [editing, setEditing] = useState(false)
 
   const onSave = data => {
@@ -91,7 +73,7 @@ const Item = props => {
         </Dialog>
       ) : null}
       <IndexCardItem {...form} onClick={() => setEditing(true)}>
-        <Actions attributes={form} user={user}>
+        <Actions attributes={form}>
           <ShareAction
             id={form.id}
             title={form.title}
@@ -104,7 +86,6 @@ const Item = props => {
               id={form.id}
               title={form.title}
               metacardType="attribute-group"
-              isAdmin={canShare}
             />
             <EditMetacardInteraction
               itemName="Result Form"
@@ -113,7 +94,6 @@ const Item = props => {
             <ConfirmDeleteMetacardInteraction
               itemName="Result Form"
               onDelete={onDelete}
-              isWritable={canWrite}
             />
           </MetacardInteractionsDropdown>
         </Actions>
@@ -134,7 +114,6 @@ export const Route = props => {
     onSave,
     onDelete,
     refetch,
-    userAttributes,
   } = props
 
   if (loading) {
@@ -180,7 +159,6 @@ export const Route = props => {
                 setMessage('Result Form Deleted')
               }}
               form={form}
-              user={userAttributes}
             />
           )
         })}
@@ -215,10 +193,6 @@ const resultForms = gql`
         ...ResultFormAttributes
       }
     }
-    user {
-      email
-      roles
-    }
   }
   ${fragment}
 `
@@ -236,22 +210,16 @@ const useCreate = () => {
   return useMutation(mutation, {
     update: (cache, { data }) => {
       const query = resultForms
-      const { metacardsByTag, user } = cache.readQuery({ query })
+      const { metacardsByTag } = cache.readQuery({ query })
       const attributes = metacardsByTag.attributes
         .filter(({ id }) => id !== data.createMetacard.id)
         .concat(data.createMetacard)
-      const { email, roles } = user
       cache.writeQuery({
         query,
         data: {
           metacardsByTag: {
             attributes,
             __typename: 'QueryResponse',
-          },
-          user: {
-            email,
-            roles,
-            __typename: 'User',
           },
         },
       })
@@ -401,7 +369,6 @@ export default () => {
   }
 
   const forms = data.metacardsByTag.attributes
-  const user = data.user
 
   return (
     <Route
@@ -411,7 +378,6 @@ export default () => {
       onSave={onSave}
       onDelete={onDelete}
       refetch={refetch}
-      userAttributes={user}
     />
   )
 }

--- a/src/main/webapp/components/search-forms/container.tsx
+++ b/src/main/webapp/components/search-forms/container.tsx
@@ -29,10 +29,6 @@ const searchForms = gql`
         ...SearchFormAttributes
       }
     }
-    user {
-      email
-      roles
-    }
   }
   ${fragment}
 `
@@ -104,19 +100,12 @@ const useCreate = () => {
         .filter(({ id }: { id: string }) => id !== data.createMetacard.id)
         .concat(data.createMetacard)
 
-      const user = getIn(cache.readQuery({ query }), ['user'], {})
-      const { email, roles } = user
       cache.writeQuery({
         query,
         data: {
           metacardsByTag: {
             attributes,
             __typename: 'QueryResponse',
-          },
-          user: {
-            email,
-            roles,
-            __typename: 'User',
           },
         },
       })
@@ -191,7 +180,6 @@ export default () => {
     updateUserPrefs(userPreferences)
   }
 
-  const userAttributes = getIn(data, ['user'], [])
   return (
     <SearchFormsRoute
       onCreate={onCreate}
@@ -203,7 +191,6 @@ export default () => {
       userDefaultForm={userDefaultForm}
       toggleDefaultForm={toggleDefaultForm}
       refetch={refetch}
-      userAttributes={userAttributes}
     />
   )
 }

--- a/src/main/webapp/components/search-forms/search-forms.stories.tsx
+++ b/src/main/webapp/components/search-forms/search-forms.stories.tsx
@@ -44,10 +44,10 @@ const startingForms = [
   },
 ]
 
-const userAttributes = {
-  email: 'admin@test.com',
-  roles: ['admin'],
-}
+// const userAttributes = {
+//   email: 'admin@test.com',
+//   roles: ['admin'],
+// }
 
 stories.add('route', () => {
   const [searchForms, setSearchForms]: any = useState(startingForms)
@@ -91,7 +91,6 @@ stories.add('route', () => {
         toggleDefaultForm={id => {
           setDefaultForm(id === defaultForm ? null : id)
         }}
-        userAttributes={userAttributes}
       />
     </SelectionProvider>
   )

--- a/src/main/webapp/components/sharing/sharing-modal.js
+++ b/src/main/webapp/components/sharing/sharing-modal.js
@@ -14,7 +14,8 @@ import {
 
 const ShareMetacardInteraction = props => {
   const { setDialogProps } = useContext(MetacardInteractionsDialogContext)
-  if (!props.isAdmin) {
+  const { permissions } = props
+  if (!permissions.canShare) {
     return null
   }
   return (

--- a/src/main/webapp/components/workspace/workspace-context.js
+++ b/src/main/webapp/components/workspace/workspace-context.js
@@ -1,0 +1,2 @@
+import React from 'react'
+export const WorkspaceContext = React.createContext()

--- a/src/main/webapp/components/workspaces/workspaces.js
+++ b/src/main/webapp/components/workspaces/workspaces.js
@@ -25,15 +25,11 @@ import { Notification } from '../notification/notification'
 import { useClone, useCreate, useDelete, useSubscribe } from './hooks/'
 import { SubscribeAction, SubscribeMetacardInteraction } from './subscribe'
 import FilterWorkspaces from './filter-workspaces'
-const {
-  getPermissions,
-  getSecurityAttributesFromMetacard,
-} = require('../sharing/sharing-utils')
 
 const LoadingComponent = () => <LinearProgress />
 
 const Workspaces = props => {
-  const { workspaces, onCreate, onDelete, onDuplicate, userAttributes } = props
+  const { workspaces, onCreate, onDelete, onDuplicate } = props
   const [subscribe, unsubscribe] = useSubscribe()
   const [message, setMessage] = React.useState(null)
   const history = useHistory()
@@ -52,13 +48,6 @@ const Workspaces = props => {
       {workspaces.map(workspace => {
         const isSubscribed = workspace.userIsSubscribed
         workspace = workspace.attributes
-        const securityAttributes = getSecurityAttributesFromMetacard(workspace)
-        const { canShare, canWrite } = getPermissions(
-          userAttributes.email,
-          userAttributes.roles,
-          securityAttributes,
-          workspace.owner
-        )
         return (
           <IndexCardItem
             {...workspace}
@@ -90,7 +79,6 @@ const Workspaces = props => {
                   id={workspace.id}
                   title={workspace.title}
                   metacardType="workspace"
-                  isAdmin={canShare}
                 />
                 <EditMetacardInteraction
                   itemName="Workspace"
@@ -99,7 +87,6 @@ const Workspaces = props => {
                 <ConfirmDeleteMetacardInteraction
                   itemName="Workspace"
                   onDelete={() => onDelete(workspace)}
-                  isWritable={canWrite}
                 />
                 <DuplicateMetacardInteraction
                   onDuplicate={() => onDuplicate(workspace)}
@@ -167,7 +154,6 @@ export default () => {
         onCreate={onCreate}
         onDelete={onDelete}
         onDuplicate={onDuplicate}
-        userAttributes={data.user}
       />
     </React.Fragment>
   )

--- a/src/main/webapp/react-hooks/use-get-permissions.tsx
+++ b/src/main/webapp/react-hooks/use-get-permissions.tsx
@@ -27,11 +27,11 @@ const user = gql`
 `
 
 const usePermissions = (user: User = {}) => {
-  return (attributes: any) => {
+  return (attributes: any = {}) => {
     const securityAttributes = getSecurityAttributesFromMetacard(attributes)
     return getPermissions(
       user.email || '',
-      user.roles || '',
+      user.roles || [],
       securityAttributes,
       attributes.owner
     )

--- a/src/main/webapp/react-hooks/use-get-permissions.tsx
+++ b/src/main/webapp/react-hooks/use-get-permissions.tsx
@@ -10,6 +10,13 @@ type User = {
   email?: string
   roles?: string[]
 }
+
+export type Permissions = {
+  canShare: boolean
+  canWrite: boolean
+  readOnly: boolean
+}
+
 const user = gql`
   query UserEmailAndRoles {
     user {
@@ -19,12 +26,12 @@ const user = gql`
   }
 `
 
-const usePermissions = (user: User) => {
+const usePermissions = (user: User = {}) => {
   return (attributes: any) => {
     const securityAttributes = getSecurityAttributesFromMetacard(attributes)
     return getPermissions(
-      user.email,
-      user.roles,
+      user.email || '',
+      user.roles || '',
       securityAttributes,
       attributes.owner
     )
@@ -40,6 +47,6 @@ const usePermissionsWithQuery = () => {
   return usePermissions(data.user)
 }
 
-export default ({ user = {} }: { user: User }) => {
-  return useApolloFallback(usePermissionsWithQuery, usePermissions)(user)
+export default () => {
+  return useApolloFallback(usePermissionsWithQuery, usePermissions)()
 }


### PR DESCRIPTION
Also adds context to workspaces so that security attributes can be passed down for query cards to show available actions. https://github.com/connexta/revelio/pull/333/commits/904b35a44d5821b60a3ac11e81e542bda775d188