### PR TITLE
Fix Query in simple search when selecting sources

### DIFF
--- a/src/main/webapp/components/basic-search/basic-search.js
+++ b/src/main/webapp/components/basic-search/basic-search.js
@@ -266,7 +266,7 @@ const createQuery = filterMap => {
 
   return {
     filterTree: toFilterTree(filterMap),
-    sources: sources || null,
+    sourceIds: sources || null,
     sorts,
   }
 }

--- a/src/main/webapp/components/basic-search/basic-search.js
+++ b/src/main/webapp/components/basic-search/basic-search.js
@@ -266,7 +266,7 @@ const createQuery = filterMap => {
 
   return {
     filterTree: toFilterTree(filterMap),
-    sourceIds: sources || null,
+    sources: sources || null,
     sorts,
   }
 }

--- a/src/main/webapp/components/simple-search/simple-search.js
+++ b/src/main/webapp/components/simple-search/simple-search.js
@@ -40,6 +40,12 @@ const SimpleSearch = props => {
     setShowInspector(true)
   }
 
+  const transformToSourceIds = query => {
+    if (query.sources) {
+      query.sourceIds = query.sources.map(source => source)
+      delete query.sources
+    }
+  }
   return (
     <div
       style={{
@@ -69,6 +75,7 @@ const SimpleSearch = props => {
               setPageIndex(0)
               setQuery(query)
               onClear()
+              transformToSourceIds(query)
               onSearch(query)
             }}
           />


### PR DESCRIPTION
When doing a simple search for a specific source all sources are still queried 
Fixes: #345

When use-query-executor was bieng called for `onSearch` a check exists wether or not `sourceIds` exist or not. if they dont query all sources. in Simple Search `sources` was being passed rather than `sourceIds` which caused it to query all sources