### PR TITLE
Result table default to expandable cell

### DIFF
--- a/src/main/webapp/components/results/results.js
+++ b/src/main/webapp/components/results/results.js
@@ -47,7 +47,7 @@ const ExpandButton = props => {
   )
 }
 
-const Description = props => {
+const Expandable = props => {
   const [expanded, setExpanded] = useState(false)
   const { text = '' } = props
   const long = text.length > 250
@@ -187,10 +187,8 @@ const getCellContent = (attribute, value) => {
           <Thumbnail src={value} />
         </div>
       )
-    case 'description':
-      return <Description text={value} />
     default:
-      return <Typography style={{ ...cellStyles }}>{value}</Typography>
+      return <Expandable text={value} />
   }
 }
 


### PR DESCRIPTION
Defaulting cells to be expandable so long texts values will be collapsed.

Image of collapsed metadata field:
![image](https://user-images.githubusercontent.com/14877145/80833880-65f9f980-8ba4-11ea-9e66-97f6e43c0de3.png)
