### PR TITLE
Make material-data fields happy #362

### DIFF
--- a/src/main/webapp/components/results/result-material-table.js
+++ b/src/main/webapp/components/results/result-material-table.js
@@ -49,11 +49,11 @@ const onColumnDragged = (onColumnUpdate, columns) => () => {
       .sort((a, b) => {
         return a.tableData.columnOrder - b.tableData.columnOrder
       })
-      .map(column => column.title)
+      .map(column => column.original)
 
     const columnHide = columns
       .filter(column => column.hidden)
-      .map(column => column.title)
+      .map(column => column.original)
 
     onColumnUpdate({ columnOrder, columnHide })
   }

--- a/src/main/webapp/components/results/results.js
+++ b/src/main/webapp/components/results/results.js
@@ -87,10 +87,10 @@ const TransferListModal = props => {
   }
 
   const handleSave = () => {
-    const order = columnOrder.map(column => column.title)
+    const order = columnOrder.map(column => column.original)
     const columnHide = columnOrder
       .filter(column => column.hidden)
-      .map(column => column.title)
+      .map(column => column.original)
 
     if (typeof onColumnUpdate === 'function') {
       onColumnUpdate({ columnOrder: order, columnHide })
@@ -198,10 +198,19 @@ const RenderAttribute = field => rowData => {
   return getCellContent(field, rowData[field])
 }
 
+const fixFieldAttribute = attribute => {
+  if (attribute.includes('.')) {
+    return attribute.replace('.', '_')
+  }
+
+  return attribute
+}
+
 const attributeToColumn = (attribute, hidden = true) => {
   return {
     title: attribute,
-    field: attribute,
+    field: fixFieldAttribute(attribute),
+    original: attribute,
     render: RenderAttribute(attribute),
     hidden,
   }


### PR DESCRIPTION
Changing column field names to make material-table happy.

If the table data doesn't contain a value for a column field, it checks to see if the field has a `.`. If it does, it tries to parse it as an object by looking for a field matching the string before the
  `.`. 

Our fields do have a `.` in them but shouldn't be treated as objects. 
This is causing errors in material table.
We have `location.country-code` and `location` and material-table is trying to parse the location attribute for country-code and this is what's causing the error.

Fixes #362 